### PR TITLE
Simplify all call routes to use /

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ mm-plugin-apps: `master`
     1. `Add OAuth Client`
         1. `Client Name`: (Example `Mattermost Zendesk App`)
         1. `Description`: `Connect your Zendesk account to Mattermost`
-        1. `Redirect URLs`: `https://<your-zendesk-app-host>/mattermost/oauth/complete`
+        1. `Redirect URLs`: `https://<your-zendesk-app-host>/oauth/complete`
             1. Ex. `http://localhost:4000` - Development
             1. Ex. `https://mytest.ngrok.io` - Exposed for development
         1. `Save`
@@ -28,14 +28,14 @@ mm-plugin-apps: `master`
         1. Set `ZD_URL` to your zendesk account host
             1. Ex. `https://<subdomain>.zendesk.com`
         1. Set `ZD_NODE_HOST` to the path of you zendesk app host
-            1. Ex. `https://https://testing.ngrok.io/mattermost`
+            1. Ex. `https://https://testing.ngrok.io`
     1. `ZD_CLIENT_SECRET` - (will be set later in the setup)
 1. Start the node server
     1. `npm i` - install node_moduls and dependencies
     1. `npm run build:watch` - (to monitor typescriopt errors and watch chaning files errors)
     1. `npm start` - (in a separate shell) start the node server
 1. Install the app (In Mattermost)
-    1. `/apps install --url http://<your-zendesk-app-host>/mattermost/manifest.json --app-secret thisisthesecret`  
+    1. `/apps install --url http://<your-zendesk-app-host>/manifest.json --app-secret thisisthesecret`  
 
 ### Zendesk and Mattermost Users (All users)
 
@@ -59,8 +59,8 @@ Creating a ticket from a Mattermost post is done through the `...` post menu but
 
 ## Installation
 
-`/apps install --url http://<your-zendesk-app>/mattermost/manifest.json --app-secret thisisthesecret`  
-`/apps install --url http://localhost:4000/mattermost/manifest.json --app-secret thisisthesecret`  
+`/apps install --url http://<your-zendesk-app>/manifest.json --app-secret thisisthesecret`  
+`/apps install --url http://localhost:4000/manifest.json --app-secret thisisthesecret`  
 
 After installing the app, a provisioned bot account will be created for user `@zendesk` and posted in a DM. The following values are stored locally in `config.json`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ app.use(bodyParser.urlencoded({
 }));
 
 app.use('/zendesk', zdRoutes); // Zendesk router
-app.use('/mattermost', mmRoutes); // Mattermost router
+app.use('/', mmRoutes); // Mattermost router
 
 if (isRunningInHTTPMode()) {
     // Listen to http port

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,6 +16,12 @@
         "/post_menu",
         "/in_post"
     ],
+    "on_install": {
+        "url": "/install"
+    },
+    "bindings": {
+        "url": "/bindings"
+    },
     "functions": [
         {
             "name": "js-function",


### PR DESCRIPTION
#### Summary
The code didn't take into account that `/mattermost/` was used as a subpath. This PR fixes that issue by removing the subpath.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33053