### PR TITLE
Use dist to create bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ From [Zendesk Documentation:](https://developer.zendesk.com/rest_api/docs/suppor
 }
 ```
 
+## Provision
+
+To provision this PR to AWS run `npm run dist` to generate the App bundle and then follow the steps [here](https://github.com/mattermost/mattermost-plugin-apps#provisioning).
+
 ## FAQ
 
 ### 1. `npm start` fails with warning about rudder in mattermost-redux

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc -p .",
     "build:watch": "tsc -w -p .",
     "clean": "rm -rf dist node_modules",
-    "package": "rm -rf dist; npm run build; cp -r node_modules dist; cd dist; zip -qr js-function * node_modules; zip -r bundle.zip js-function.zip manifest.json",
+    "dist": "rm -rf dist; npm run build; cp -r node_modules dist; cd dist; zip -qr js-function * node_modules; zip -r bundle.zip js-function.zip manifest.json",
     "start": "LOCAL=true nodemon dist/index.js",
     "test": "jest --coverage",
     "rebuild": "rm -rf node_modules; rm -f package-lock.json; npm i; npm run build"


### PR DESCRIPTION
#### Summary
Similar to plugin the command to create the bundle should be behind a `dist` command. I've also added a link the `appsctl`.

#### Ticket Link
Follow up on https://github.com/mattermost/mattermost-app-servicenow/pull/2

