### PR TITLE
Allow updating shared access_token via slash command and not through config modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ This step requires a Zendesk-connected Mattermost system administrator and uses 
 
 Note, the access token is only used to read ticket information when a subcription is triggered. This token will not post on behalf of the user.
 
-1. `/zendesk setup-target` - This command will set up a Zendesk target pointing to your Mattermost instance (it only needs to be run once). The command also uses saves the access_token for the acting user for subscriptions functionality.
+1. `/zendesk setup-target` - This command will set up a Zendesk target pointing to your Mattermost instance (it only needs to be run once).
+1. The command also saves the access_token of the acting user for subscriptions functionality.
 1. An ephemeral post will confirm that a target was created and that subscriptions functionality has been configured.
 
 ## Notification management

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Use the values from the OAuth client set up step:
 1. **URL:** Set to your Zendesk URL.
 1. **Client ID:** Set to the **Unique identifier** OAuth value.
 1. **Client Secret:** Set as the **Secret** OAuth value.
-1. **OAuth2 Access Token:** Leave empty for now - you'll configure this once you're connected.
 
 Select **Submit**.
 
@@ -63,14 +62,11 @@ Select **Submit**.
 
 #### 5. Set up subscriptions
 
-This step requires a Zendesk-connected Mattermost user and uses an access token needed for subscriptions functionality. The token can be any connected Zendesk user with agent permissions in Zendesk. Another option is to create a bot agent user in Zendesk, that will function as a service account, and connect them to Mattermost.
+This step requires a Zendesk-connected Mattermost system administrator and uses an access token needed for subscriptions functionality. The token can be any connected Zendesk user with agent permissions in Zendesk. Another option is to create a bot agent user in Zendesk, that will function as a service account, and connect them to Mattermost.
 
 Note, the access token is only used to read ticket information when a subcription is triggered. This token will not post on behalf of the user.
 
-1. `/zendesk me` - Save this access token value.
-1. `/zendesk configure`:
-    1. `Oauth2 Access Token` - Set this value to the token saved in the step above and select **Submit**.
-1. `/zendesk setup-target` - This command will set up a Zendesk target pointing to your Mattermost instance (it only needs to be run once).
+1. `/zendesk setup-target` - This command will set up a Zendesk target pointing to your Mattermost instance (it only needs to be run once). The command also uses saves the access_token for the acting user for subscriptions functionality.
 1. An ephemeral post will confirm that a target was created and that subscriptions functionality has been configured.
 
 ## Notification management
@@ -100,7 +96,6 @@ This slash command connects your Mattermost and Zendesk accounts via OAuth2 auth
 - `/zendesk connect` - Connect your Zendesk account to Mattermost.
 - `/zendesk disconnect` - Disconnect your Zendesk account from Mattermost.
 - `/zendesk help` - Post ephemeral message with help text.
-- `/zendesk me` - Post ephemeral message with your connection information.
 
  ## Create a ticket
 

--- a/src/bindings/channel_header.ts
+++ b/src/bindings/channel_header.ts
@@ -1,7 +1,7 @@
 import {AppBinding} from 'mattermost-redux/types/apps';
 import {AppExpandLevels} from 'mattermost-redux/constants/apps';
 
-import {getStaticURL, Routes, newChannelHeaderBindings} from '../utils';
+import {getStaticURL, Routes, newChannelHeaderBindings, isZdAdmin} from '../utils';
 import {Locations, ZendeskIcon} from '../utils/constants';
 import {getManifest} from '../manifest';
 
@@ -10,7 +10,7 @@ import {BindingOptions} from './index';
 // getChannelHeaderBindings returns the users command bindings
 export const getChannelHeaderBindings = (options: BindingOptions): AppBinding => {
     const bindings: AppBinding[] = [];
-    if (options.isSystemAdmin && options.isConnected) {
+    if (options.isConnected && isZdAdmin(options.zdUserRole)) {
         bindings.push(channelHeaderSubscribe(options.mattermostSiteUrl));
     }
     return newChannelHeaderBindings(bindings);

--- a/src/bindings/index.ts
+++ b/src/bindings/index.ts
@@ -1,7 +1,8 @@
 import {AppBinding} from 'mattermost-redux/types/apps';
 
 import {CtxExpandedActingUserOauth2AppOauth2User} from 'types/apps';
-import {isConfigured, isConnected, isUserSystemAdmin, isZdAgent} from '../utils';
+import {isConfigured, isConnected, isUserSystemAdmin} from '../utils';
+import {ZDRole} from '../utils/ZDTypes';
 
 import {getCommandBindings} from './slash_commands';
 import {getPostMenuBindings} from './post_menu';
@@ -11,7 +12,7 @@ export type BindingOptions = {
     isSystemAdmin: boolean,
     isConfigured: boolean,
     isConnected: boolean
-    isZdAgent: boolean
+    zdUserRole: ZDRole,
     mattermostSiteUrl: string
 }
 export async function getBindings(context: CtxExpandedActingUserOauth2AppOauth2User): Promise<AppBinding[]> {
@@ -19,7 +20,7 @@ export async function getBindings(context: CtxExpandedActingUserOauth2AppOauth2U
         isSystemAdmin: isUserSystemAdmin(context.acting_user),
         isConfigured: isConfigured(context.oauth2),
         isConnected: isConnected(context.oauth2.user),
-        isZdAgent: isZdAgent(context.oauth2.user),
+        zdUserRole: context.oauth2.user?.role,
         mattermostSiteUrl: context.mattermost_site_url,
     };
 

--- a/src/bindings/post_menu.ts
+++ b/src/bindings/post_menu.ts
@@ -2,6 +2,7 @@ import {AppBinding} from 'mattermost-redux/types/apps';
 import {AppExpandLevels} from 'mattermost-redux/constants/apps';
 
 import {Routes, Locations, ZendeskIcon} from '../utils/constants';
+import {isZdAdmin, isZdAgent} from '../utils/utils';
 import {getStaticURL, newPostMenuBindings} from '../utils';
 import {getManifest} from '../manifest';
 
@@ -11,16 +12,16 @@ import {BindingOptions} from './index';
 export const getPostMenuBindings = (options: BindingOptions): AppBinding => {
     const bindings: AppBinding[] = [];
 
-    if (!options.isZdAgent) {
-        return newPostMenuBindings(bindings);
-    }
-
     // do not show any post menu options if the app is not configured
     if (!options.isConfigured) {
         return newPostMenuBindings(bindings);
     }
+
+    // admins and agents can create tickets in Zendesk
     if (options.isConnected) {
-        bindings.push(openCreateTicketForm(options.mattermostSiteUrl));
+        if (isZdAdmin(options.zdUserRole) || isZdAgent(options.zdUserRole)) {
+            bindings.push(openCreateTicketForm(options.mattermostSiteUrl));
+        }
     }
     return newPostMenuBindings(bindings);
 };

--- a/src/bindings/slash_commands.ts
+++ b/src/bindings/slash_commands.ts
@@ -3,6 +3,7 @@ import {AppExpandLevels} from 'mattermost-redux/constants/apps';
 
 import {Routes, Locations, ZendeskIcon} from '../utils/constants';
 import {getStaticURL, newCommandBindings} from '../utils';
+import {isZdAdmin} from '../utils/utils';
 import {BindingOptions} from 'bindings';
 import {getManifest} from '../manifest';
 
@@ -20,9 +21,12 @@ export const getCommandBindings = (options: BindingOptions): AppBinding => {
         }
     }
     if (options.isConnected) {
-        if (options.isSystemAdmin && options.isZdAgent) {
+        // only admins can create triggers and targets in zendesk
+        if (isZdAdmin(options.zdUserRole)) {
             bindings.push(cmdSubscribe(mmSiteURL));
-            bindings.push(cmdTarget(mmSiteURL));
+            if (options.isSystemAdmin) {
+                bindings.push(cmdTarget(mmSiteURL));
+            }
         }
         bindings.push(cmdDisconnect(mmSiteURL));
 

--- a/src/bindings/slash_commands.ts
+++ b/src/bindings/slash_commands.ts
@@ -25,7 +25,8 @@ export const getCommandBindings = (options: BindingOptions): AppBinding => {
             bindings.push(cmdTarget(mmSiteURL));
         }
         bindings.push(cmdDisconnect(mmSiteURL));
-        bindings.push(cmdMe(mmSiteURL));
+
+        // bindings.push(cmdMe(mmSiteURL));
     } else {
         bindings.push(cmdConnect(mmSiteURL));
     }

--- a/src/forms/zendesk_config.ts
+++ b/src/forms/zendesk_config.ts
@@ -69,7 +69,6 @@ class FormFields extends BaseFormFields {
         this.addZDUrlField();
         this.addZDClientIDField();
         this.addZDClientSecretField();
-        this.addZDConnectedUserIDField();
     }
 
     addZDUrlField(): void {
@@ -105,18 +104,6 @@ class FormFields extends BaseFormFields {
             value: this.OauthValues.client_secret,
             description: 'Client Secret obtained from Zendesk Oauth client secret',
             is_required: true,
-        };
-        this.builder.addField(f);
-    }
-
-    addZDConnectedUserIDField(): void {
-        const f: AppField = {
-            type: AppFieldTypes.TEXT,
-            subtype: 'password',
-            name: 'zd_oauth_access_token',
-            label: 'Oauth2 Access Token',
-            value: this.storeValues.zd_oauth_access_token,
-            description: 'Oauth2 Connected Mattermost Account with Zendesk agent access. This field is needed for subscriptions',
         };
         this.builder.addField(f);
     }

--- a/src/restapi/fConfig.ts
+++ b/src/restapi/fConfig.ts
@@ -37,8 +37,10 @@ export async function fSubmitOrUpdateZendeskConfigSubmit(req: Request, res: Resp
         const configStore = newConfigStore(context.bot_access_token, context.mattermost_site_url);
         const cValues = await configStore.getValues();
         const targetID = cValues.zd_target_id;
+        const zdOauth2AccessToken = cValues.zd_oauth_access_token;
         const storeValues = call.values as AppConfigStore;
         storeValues.zd_target_id = targetID;
+        storeValues.zd_oauth_access_token = zdOauth2AccessToken;
         configStore.storeConfigInfo(storeValues);
     } catch (err) {
         callResponse = newErrorCallResponseWithMessage(err.message);

--- a/src/restapi/fConnect.ts
+++ b/src/restapi/fConnect.ts
@@ -51,7 +51,7 @@ export async function fOauth2Complete(req: Request, res: Response): Promise<void
         token: {
             access_token: '',
         },
-        is_agent: false,
+        role: '',
     };
 
     const code = call.values.code;
@@ -74,10 +74,8 @@ export async function fOauth2Complete(req: Request, res: Response): Promise<void
     const zdClient = await newZDClient(zdOptions);
     const me = await zdClient.users.me();
     let dmText = 'You have successfully connected your Zendesk account!';
-    let isAgent = true;
-    if (me.role !== ZDRoles.admin) {
-        isAgent = false;
-        dmText += '  This app currently supports Zendesk admin accounts and does not provide any features for end-user accounts.';
+    if (me.role !== ZDRoles.admin && me.role !== ZDRoles.agent) {
+        dmText += '  This app currently supports Zendesk admin and agent accounts and does not provide any features for end-user accounts.';
     }
 
     const mmURL = context.mattermost_site_url;
@@ -85,7 +83,7 @@ export async function fOauth2Complete(req: Request, res: Response): Promise<void
 
     const storedToken: StoredOauthUserToken = {
         token,
-        is_agent: isAgent,
+        role: me.role,
     };
     await ppClient.storeOauth2User(storedToken);
     const app = newApp(call);

--- a/src/restapi/fConnect.ts
+++ b/src/restapi/fConnect.ts
@@ -73,7 +73,7 @@ export async function fOauth2Complete(req: Request, res: Response): Promise<void
     };
     const zdClient = await newZDClient(zdOptions);
     const me = await zdClient.users.me();
-    let dmText = 'You have successfully connected your Zendesk acccount!';
+    let dmText = 'You have successfully connected your Zendesk account!';
     let isAgent = true;
     if (me.role !== ZDRoles.admin) {
         isAgent = false;

--- a/src/restapi/fDisconnect.ts
+++ b/src/restapi/fDisconnect.ts
@@ -19,7 +19,7 @@ export async function fDisconnect(req: Request, res: Response): Promise<void> {
     // get the saved service account config zendesk access_token
     const config = await newConfigStore(context.bot_access_token, context.mattermost_site_url).getValues();
     const configOauthToken = config.zd_oauth_access_token;
-    const text = 'This mattermost account is connected via oauth2 to Zendesk for subscription functionality. The account cannot be disconnected until the access token in the configuration is updated to a new user access token. To do this, please have another connected system administrator with Zendesk Admin privileges run `/zendesk setup-target`';
+    const text = 'This mattermost account is connected via oauth2 to Zendesk for subscription functionality and cannot be disconnected until the access token is updated to a new user access token. To do this, please have another connected system administrator with Zendesk Admin privileges run `/zendesk setup-target`';
     if (context.oauth2.user.token.access_token === configOauthToken) {
         res.json(newOKCallResponseWithMarkdown(text));
         return;

--- a/src/restapi/fDisconnect.ts
+++ b/src/restapi/fDisconnect.ts
@@ -19,7 +19,7 @@ export async function fDisconnect(req: Request, res: Response): Promise<void> {
     // get the saved service account config zendesk access_token
     const config = await newConfigStore(context.bot_access_token, context.mattermost_site_url).getValues();
     const configOauthToken = config.zd_oauth_access_token;
-    const text = 'This mattermost account is connected via oauth2 to Zendesk for subscription functionality. The account cannot be disconnected until the access token in the configuration is updated to a new user access token.';
+    const text = 'This mattermost account is connected via oauth2 to Zendesk for subscription functionality. The account cannot be disconnected until the access token in the configuration is updated to a new user access token. To do this, please have another connected system administrator with Zendesk Admin privileges run `/zendesk setup-target`';
     if (context.oauth2.user.token.access_token === configOauthToken) {
         res.json(newOKCallResponseWithMarkdown(text));
         return;

--- a/src/restapi/fDisconnect.ts
+++ b/src/restapi/fDisconnect.ts
@@ -19,7 +19,7 @@ export async function fDisconnect(req: Request, res: Response): Promise<void> {
     // get the saved service account config zendesk access_token
     const config = await newConfigStore(context.bot_access_token, context.mattermost_site_url).getValues();
     const configOauthToken = config.zd_oauth_access_token;
-    const text = 'This mattermost account is connected via oauth2 to Zendesk for subscription functionality and cannot be disconnected until the access token is updated to a new user access token. To do this, please have another connected system administrator with Zendesk Admin privileges run `/zendesk setup-target`';
+    const text = 'This mattermost account is connected via oauth2 to Zendesk for subscription functionality and cannot be disconnected until the access token is updated to a new user access token. Please have another connected system administrator with Zendesk Admin privileges run `/zendesk setup-target` to update the access_token';
     if (context.oauth2.user.token.access_token === configOauthToken) {
         res.json(newOKCallResponseWithMarkdown(text));
         return;

--- a/src/restapi/fDisconnect.ts
+++ b/src/restapi/fDisconnect.ts
@@ -19,7 +19,7 @@ export async function fDisconnect(req: Request, res: Response): Promise<void> {
     // get the saved service account config zendesk access_token
     const config = await newConfigStore(context.bot_access_token, context.mattermost_site_url).getValues();
     const configOauthToken = config.zd_oauth_access_token;
-    const text = 'This mattermost account is connected via oauth2 to Zendesk for subscription functionality and cannot be disconnected until the access token is updated to a new user access token. Please have another connected system administrator with Zendesk Admin privileges run `/zendesk setup-target` to update the access_token';
+    const text = 'This mattermost account is connected via oauth2 to Zendesk for subscription functionality and cannot be disconnected until the access token is updated to a new user access token. Please have another connected Mattermost System Admin user with Zendesk Admin privileges run `/zendesk setup-target` to update the access_token';
     if (context.oauth2.user.token.access_token === configOauthToken) {
         res.json(newOKCallResponseWithMarkdown(text));
         return;
@@ -34,7 +34,7 @@ export async function fDisconnect(req: Request, res: Response): Promise<void> {
 
     // delete the token from the proxy app
     const ppClient = newAppsClient(context.acting_user_access_token, context.mattermost_site_url);
-    await ppClient.storeOauth2User({token: {}, is_agent: false});
+    await ppClient.storeOauth2User({token: {}, role: ''});
 
     // delete the zendesk user oauth token
     const deleteReq = zdClient.oauthtokens.revoke(tokenID);

--- a/src/restapi/fHelp.ts
+++ b/src/restapi/fHelp.ts
@@ -32,7 +32,6 @@ function getUserCommands(): string {
     let text = h5('User Commands');
     text += addBulletSlashCommand('connect');
     text += addBulletSlashCommand('disconnect');
-    text += addBulletSlashCommand('me');
     text += addBulletSlashCommand('help');
     return text;
 }

--- a/src/restapi/fTarget.ts
+++ b/src/restapi/fTarget.ts
@@ -2,12 +2,12 @@ import {Request, Response} from 'express';
 
 import {getManifest} from '../manifest';
 import {Routes, tryPromiseWithMessage} from '../utils';
-import {webhookConfigured} from '../utils/utils';
+import {webhookConfigured, isZdAgent} from '../utils/utils';
 import {newZDClient, ZDClient} from '../clients';
 import {ZDClientOptions} from 'clients/zendesk';
 import {newConfigStore} from '../store';
 import {newOKCallResponseWithMarkdown} from '../utils/call_responses';
-import {CtxExpandedBotApp} from 'types/apps';
+import {CtxExpandedBotAppActingUserOauth2AppOauth2User} from 'types/apps';
 
 export async function fCreateTarget(req: Request, res: Response): Promise<void> {
     const context = req.body.context;
@@ -23,7 +23,16 @@ export async function fCreateTarget(req: Request, res: Response): Promise<void> 
 }
 
 // updateOrCreateTarget creates a target or updates an the exising target
-async function updateOrCreateTarget(zdClient: ZDClient, context: CtxExpandedBotApp): Promise<string> {
+async function updateOrCreateTarget(zdClient: ZDClient, context: CtxExpandedBotAppActingUserOauth2AppOauth2User): Promise<string> {
+    if (!context.oauth2) {
+        throw new Error('failed to get oauth2 user');
+    }
+
+    const oauth2User = context.oauth2.user;
+    if (!isZdAgent(oauth2User)) {
+        return 'only Zendesk agents can setup the target';
+    }
+
     const config = newConfigStore(context.bot_access_token, context.mattermost_site_url);
     const cValues = await config.getValues();
     const siteUrl = context.mattermost_site_url;
@@ -42,7 +51,14 @@ async function updateOrCreateTarget(zdClient: ZDClient, context: CtxExpandedBotA
     const host = cValues.zd_url;
     const link = '[Zendesk target](' + host + '/agent/admin/extensions)';
 
-    // update or create the target
+    // add the user access_token to to the store
+    if (oauth2User.token && oauth2User.token.access_token) {
+        cValues.zd_oauth_access_token = oauth2User.token.access_token;
+    } else {
+        throw new Error('failed to get oauth2 user access_token');
+    }
+
+    // update the existing target
     if (webhookConfigured(cValues)) {
         const id = cValues.zd_target_id;
 
@@ -54,6 +70,7 @@ async function updateOrCreateTarget(zdClient: ZDClient, context: CtxExpandedBotA
         return `Successfully updated ${link}`;
     }
 
+    // create the target
     const createReq = zdClient.targets.create(payload);
     const zdTarget = await tryPromiseWithMessage(createReq, 'Failed to create Zendesk target');
     cValues.zd_target_id = zdTarget.id;
@@ -63,7 +80,7 @@ async function updateOrCreateTarget(zdClient: ZDClient, context: CtxExpandedBotA
     return `Successfully created ${link}`;
 }
 
-function getTargetUrl(context: CtxExpandedBotApp): string {
+function getTargetUrl(context: CtxExpandedBotAppActingUserOauth2AppOauth2User): string {
     const whSecret = context.app.webhook_secret;
     const pluginName = getManifest().app_id;
     const whPath = Routes.App.SubscribeIncomingWebhookPath;

--- a/src/restapi/fTarget.ts
+++ b/src/restapi/fTarget.ts
@@ -51,7 +51,7 @@ async function updateOrCreateTarget(zdClient: ZDClient, context: CtxExpandedBotA
     const host = cValues.zd_url;
     const link = '[Zendesk target](' + host + '/agent/admin/extensions)';
 
-    // add the user access_token to to the store
+    // add the user access_token to the store
     if (oauth2User.token && oauth2User.token.access_token) {
         cValues.zd_oauth_access_token = oauth2User.token.access_token;
     } else {

--- a/src/restapi/fTarget.ts
+++ b/src/restapi/fTarget.ts
@@ -67,6 +67,7 @@ async function updateOrCreateTarget(zdClient: ZDClient, context: CtxExpandedBotA
         payload.target.id = id;
         const createReq = zdClient.targets.update(id, payload);
         await tryPromiseWithMessage(createReq, 'Failed to update Zendesk target');
+        config.storeConfigInfo(cValues);
         return `Successfully updated ${link}`;
     }
 

--- a/src/restapi/fTarget.ts
+++ b/src/restapi/fTarget.ts
@@ -2,7 +2,7 @@ import {Request, Response} from 'express';
 
 import {getManifest} from '../manifest';
 import {Routes, tryPromiseWithMessage} from '../utils';
-import {webhookConfigured, isZdAgent} from '../utils/utils';
+import {webhookConfigured, isZdAdmin} from '../utils/utils';
 import {newZDClient, ZDClient} from '../clients';
 import {ZDClientOptions} from 'clients/zendesk';
 import {newConfigStore} from '../store';
@@ -29,8 +29,8 @@ async function updateOrCreateTarget(zdClient: ZDClient, context: CtxExpandedBotA
     }
 
     const oauth2User = context.oauth2.user;
-    if (!isZdAgent(oauth2User)) {
-        return 'only Zendesk agents can setup the target';
+    if (!isZdAdmin(oauth2User.role)) {
+        return 'only Zendesk admins can create targets in Zendesk';
     }
 
     const config = newConfigStore(context.bot_access_token, context.mattermost_site_url);

--- a/src/types/apps.ts
+++ b/src/types/apps.ts
@@ -87,5 +87,6 @@ export type CtxExpandedActingUserOauth2App = ExpandedActingUser & ExpandedOauth2
 export type CtxExpandedActingUserOauth2AppOauth2User = ExpandedActingUser & ExpandedOauth2App & ExpandedOauth2User
 export type CtxExpandedActingUserOauth2AppBot = ExpandedActingUser & ExpandedOauth2App & ExpandedBot
 export type CtxExpandedBotActingUserOauth2AppOauth2User = ExpandedActingUser & ExpandedOauth2App & ExpandedBot & ExpandedOauth2User
+export type CtxExpandedBotAppActingUserOauth2AppOauth2User = ExpandedApp & ExpandedActingUser & ExpandedOauth2App & ExpandedBot & ExpandedOauth2User
 export type CtxExpandedBotActingUserAccessToken = ExpandedActingUserAccessToken & ExpandedBot
 export type CtxExpandedBotApp = ExpandedBot & ExpandedApp

--- a/src/utils/ZDTypes.ts
+++ b/src/utils/ZDTypes.ts
@@ -57,7 +57,9 @@ export type ZDTokensResponse = {
     count: number
 }
 
+export type ZDRole = 'admin' | 'agent' | ''
+
 export type StoredOauthUserToken = {
     token: ClientOAuth2.Data,
-    is_agent: boolean
+    role: ZDRole
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -192,6 +192,7 @@ ZDFieldValidation[ZDFieldTypes.Regex] = {
 
 export const ZDRoles = {
     admin: 'admin',
+    agent: 'agent',
 };
 
 // MappedZDNames are field names that need to be remapped before sending as a

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,12 +3,12 @@ import GeneralConstants from 'mattermost-redux/constants/general';
 import {Channel} from 'mattermost-redux/types/channels';
 import {UserProfile} from 'mattermost-redux/types/users';
 
-import {Oauth2App, ZDOauth2User} from '../types/apps';
+import {Oauth2App} from '../types/apps';
 import {getManifest} from '../manifest';
 import {AppConfigStore} from '../store/config';
 
-import {SubscriptionFields} from './constants';
-import {StoredOauthUserToken} from './ZDTypes';
+import {SubscriptionFields, ZDRoles} from './constants';
+import {StoredOauthUserToken, ZDRole} from './ZDTypes';
 
 export type ZDFieldOption = {
     name: string;
@@ -120,8 +120,12 @@ export function isConnected(oauth2user: StoredOauthUserToken): boolean {
     return false;
 }
 
-export function isZdAgent(oauth2user: StoredOauthUserToken): boolean {
-    return oauth2user && oauth2user.is_agent;
+export function isZdAgent(role: ZDRole): boolean {
+    return role === ZDRoles.agent;
+}
+
+export function isZdAdmin(role: ZDRole): boolean {
+    return role === ZDRoles.admin;
 }
 
 export function webhookConfigured(config: AppConfigStore): boolean {


### PR DESCRIPTION
#### Summary

This PR udpates the method for adding the shared `access_token` needed for subscriptions

#### The shared access token was previously saved via the following steps:
- user configures through modal
- user connects
- user runs `/zendesk me` command to get their `access_token`
  - **this step visibly shows the access token and is a security risk**
- user copies value, opens the config modal, pastes and clicks save.

#### This PR updates the method by adding the access_token when the user runs the `/zendesk setup-target` command
* updates README 
* removes the `/zendesk me` command from bindings, but left the `fMe.ts` file for future use.
* Updates message to user that tries `/zendesk disconnect`, but is the user with the shared `access_token`. 
  * include instructions to have another user run `/zendesk setup-target` to transfer the `access_token`.

#### Ticket Link
No ticket.  Originated from this comment.
https://github.com/mattermost/mattermost-app-zendesk/pull/51#discussion_r625255370
