### PR TITLE
Add lint rule for avoiding floating promises

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -509,6 +509,7 @@
       "files": ["**/*.tsx", "**/*.ts", "**/*.js"],
       "parser": "@typescript-eslint/parser",
       "rules": {
+        "@typescript-eslint/no-floating-promises": ["error"],
         "@typescript-eslint/no-var-requires": 0,
         "@typescript-eslint/prefer-interface": 0,
         "@typescript-eslint/indent": [

--- a/src/forms/subscriptions.ts
+++ b/src/forms/subscriptions.ts
@@ -191,7 +191,7 @@ class FormFields extends BaseFormFields {
     }
 
     // addSubCheckBoxes adds the available check box options for subscription
-    async addSubCheckBoxes(): Promise<void> {
+    addSubCheckBoxes(): void {
         const checkboxes: AppField[] = [];
         for (const box of this.checkboxes) {
             const f: AppField = {

--- a/src/restapi/fConfig.ts
+++ b/src/restapi/fConfig.ts
@@ -39,7 +39,7 @@ export async function fSubmitOrUpdateZendeskConfigSubmit(req: Request, res: Resp
         const targetID = cValues.zd_target_id;
         const storeValues = call.values as AppConfigStore;
         storeValues.zd_target_id = targetID;
-        configStore.storeConfigInfo(storeValues);
+        await configStore.storeConfigInfo(storeValues);
     } catch (err) {
         callResponse = newErrorCallResponseWithMessage(err.message);
     }

--- a/src/restapi/fTarget.ts
+++ b/src/restapi/fTarget.ts
@@ -67,7 +67,7 @@ async function updateOrCreateTarget(zdClient: ZDClient, context: CtxExpandedBotA
         payload.target.id = id;
         const createReq = zdClient.targets.update(id, payload);
         await tryPromiseWithMessage(createReq, 'Failed to update Zendesk target');
-        config.storeConfigInfo(cValues);
+        await config.storeConfigInfo(cValues);
         return `Successfully updated ${link}`;
     }
 

--- a/src/restapi/fTarget.ts
+++ b/src/restapi/fTarget.ts
@@ -59,7 +59,7 @@ async function updateOrCreateTarget(zdClient: ZDClient, context: CtxExpandedBotA
     cValues.zd_target_id = zdTarget.id;
 
     // save the targetID
-    config.storeConfigInfo(cValues);
+    await config.storeConfigInfo(cValues);
     return `Successfully created ${link}`;
 }
 


### PR DESCRIPTION
#### Summary

This PR adds an eslint rule that checks for unhandled promises.

After enabling the rule, I ran `npm run lint` to find any existing issues with promises. There were three issues it pointed out. One was for a function that was inherently not async that was being declared as async, and not awaited when called. The other two were un-awaited calls to `storeConfigInfo`.

@catalintomai I ran the lint rule on the commit that preceded https://github.com/mattermost/mattermost-app-zendesk/pull/47, and it pointed out the issues that were fixed in that PR. Namely, the calls to `ppClient.kvSet` that were previously unawaited would be caught by this lint rule, which your PR fixed those issues. The lint rule should catch any issues that may cause lambda issues going forward.

#### Ticket Link
