### PR TITLE
add image to use to build the app

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 # This will run on the internal gitlab
 # Will run only when have a tag pushed
+# Internal GitLab repo: https://git.internal.mattermost.com/mattermost/ci/mattermost-apps
 
 stages:
   - build
@@ -9,3 +10,6 @@ include:
   - project: mattermost/ci/mattermost-apps
     ref: main
     file: private.yml
+
+variables:
+  IMAGE_TO_BUILD: cimg/node:15.11.0


### PR DESCRIPTION
#### Summary
I missed it somehow but the zendesk is not a go app 🤦  and it broke the pipeline because it was waiting a go app to build.

Now we can define which image we use to build the app.

Related PR: https://github.com/mattermost/mattermost-app-servicenow/pull/31
MR in the internal jobs: https://git.internal.mattermost.com/mattermost/ci/mattermost-apps/-/merge_requests/5

#### Ticket Link
N/a

