### PR TITLE
MM-35375 use shared bindings for all locations

### DIFF
--- a/src/bindings/bindings.ts
+++ b/src/bindings/bindings.ts
@@ -1,0 +1,152 @@
+import {AppBinding} from 'mattermost-redux/types/apps';
+import {AppExpandLevels} from 'mattermost-redux/constants/apps';
+
+import {Routes, Locations, ZendeskIcon} from '../utils/constants';
+import {getStaticURL} from '../utils';
+import {getManifest} from '../manifest';
+
+export const getSubscribeBinding = (mmSiteUrl: string, label?: string): AppBinding => {
+    return {
+        app_id: getManifest().app_id,
+        location: Locations.Subscribe,
+        label: label || 'subscribe',
+        description: 'Subscribe notifications to a channel',
+        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
+        form: {fields: []},
+        call: {
+            path: Routes.App.CallPathSubsOpenForm,
+            expand: {
+                admin_access_token: AppExpandLevels.EXPAND_SUMMARY,
+                channel: AppExpandLevels.EXPAND_SUMMARY,
+                acting_user_access_token: AppExpandLevels.EXPAND_SUMMARY,
+                oauth2_user: AppExpandLevels.EXPAND_SUMMARY,
+            },
+        },
+    };
+};
+
+export const getConnectBinding = (mmSiteUrl: string): AppBinding => {
+    return {
+        app_id: getManifest().app_id,
+        location: Locations.Connect,
+        label: 'connect',
+        description: 'Connect your Zendesk account',
+        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
+        form: {fields: []},
+        call: {
+            expand: {
+                oauth2_app: AppExpandLevels.EXPAND_SUMMARY,
+            },
+            path: Routes.App.BindingPathConnect,
+        },
+    };
+};
+
+export const getDisconnectBinding = (mmSiteUrl: string): AppBinding => {
+    return {
+        app_id: getManifest().app_id,
+        location: Locations.Disconnect,
+        label: 'disconnect',
+        description: 'Disconnect your Zendesk account',
+        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
+        form: {fields: []},
+        call: {
+            expand: {
+                acting_user_access_token: AppExpandLevels.EXPAND_SUMMARY,
+                oauth2_user: AppExpandLevels.EXPAND_SUMMARY,
+            },
+            path: Routes.App.BindingPathDisconnect,
+        },
+    };
+};
+
+export const getConfigureBinding = (mmSiteUrl: string): AppBinding => {
+    return {
+        app_id: getManifest().app_id,
+        location: Locations.Configure,
+        label: 'configure',
+        description: 'Configure the installed Zendesk account',
+        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
+        form: {fields: []},
+        call: {
+            path: Routes.App.CallPathConfigOpenForm,
+            expand: {
+                acting_user: AppExpandLevels.EXPAND_SUMMARY,
+                acting_user_access_token: AppExpandLevels.EXPAND_SUMMARY,
+                oauth2_app: AppExpandLevels.EXPAND_SUMMARY,
+                oauth2_user: AppExpandLevels.EXPAND_SUMMARY,
+            },
+        },
+    };
+};
+
+export const getMeBinding = (mmSiteUrl: string): AppBinding => {
+    return {
+        app_id: getManifest().app_id,
+        location: Locations.Me,
+        label: 'me',
+        description: 'Show Your Zendesk User Info',
+        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
+        form: {fields: []},
+        call: {
+            path: Routes.App.BindingPathMe,
+            expand: {
+                oauth2_user: AppExpandLevels.EXPAND_SUMMARY,
+            },
+        },
+    };
+};
+
+export const getTargetBinding = (mmSiteUrl: string): AppBinding => {
+    return {
+        app_id: getManifest().app_id,
+        location: Locations.Target,
+        label: 'setup-target',
+        description: 'Setup Zendesk Target',
+        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
+        form: {fields: []},
+        call: {
+            path: Routes.App.BindingPathTargetCreate,
+            expand: {
+                app: AppExpandLevels.EXPAND_SUMMARY,
+                oauth2_user: AppExpandLevels.EXPAND_SUMMARY,
+            },
+        },
+    };
+};
+
+export const getHelpBinding = (mmSiteUrl: string): AppBinding => {
+    return {
+        app_id: getManifest().app_id,
+        location: Locations.Help,
+        label: 'help',
+        description: 'Show Zendesk Help',
+        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
+        form: {fields: []},
+        call: {
+            path: Routes.App.BindingPathHelp,
+            expand: {
+                acting_user: AppExpandLevels.EXPAND_SUMMARY,
+            },
+        },
+    };
+};
+
+export const getCreateTicketBinding = (mmSiteUrl: string): AppBinding => {
+    return {
+        app_id: getManifest().app_id,
+        label: 'Create Zendesk Ticket',
+        description: 'Create ticket in Zendesk',
+        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
+        location: Locations.Ticket,
+        call: {
+            path: Routes.App.CallPathTicketOpenForm,
+            expand: {
+                post: AppExpandLevels.EXPAND_SUMMARY,
+                acting_user: AppExpandLevels.EXPAND_SUMMARY,
+                acting_user_access_token: AppExpandLevels.EXPAND_SUMMARY,
+                oauth2_user: AppExpandLevels.EXPAND_SUMMARY,
+            },
+        },
+    };
+};

--- a/src/bindings/channel_header.ts
+++ b/src/bindings/channel_header.ts
@@ -1,9 +1,8 @@
 import {AppBinding} from 'mattermost-redux/types/apps';
-import {AppExpandLevels} from 'mattermost-redux/constants/apps';
 
-import {getStaticURL, Routes, newChannelHeaderBindings, isZdAdmin} from '../utils';
-import {Locations, ZendeskIcon} from '../utils/constants';
-import {getManifest} from '../manifest';
+import {newChannelHeaderBindings, isZdAdmin} from '../utils';
+
+import {getSubscribeBinding} from './bindings';
 
 import {BindingOptions} from './index';
 
@@ -11,27 +10,7 @@ import {BindingOptions} from './index';
 export const getChannelHeaderBindings = (options: BindingOptions): AppBinding => {
     const bindings: AppBinding[] = [];
     if (options.isConnected && isZdAdmin(options.zdUserRole)) {
-        bindings.push(channelHeaderSubscribe(options.mattermostSiteUrl));
+        bindings.push(getSubscribeBinding(options.mattermostSiteUrl, 'Create Subscription'));
     }
     return newChannelHeaderBindings(bindings);
-};
-
-const channelHeaderSubscribe = (mmSiteURL: string): AppBinding => {
-    return {
-        app_id: getManifest().app_id,
-        location: Locations.Subscribe,
-        label: 'Create Zendesk Subscription',
-        description: 'Open Create Zendesk Subscription Modal',
-        icon: getStaticURL(mmSiteURL, ZendeskIcon),
-        call: {
-            path: Routes.App.CallPathSubsOpenForm,
-            expand: {
-                acting_user: AppExpandLevels.EXPAND_ALL,
-                channel: AppExpandLevels.EXPAND_SUMMARY,
-                admin_access_token: AppExpandLevels.EXPAND_ALL,
-                acting_user_access_token: AppExpandLevels.EXPAND_ALL,
-                oauth2_user: AppExpandLevels.EXPAND_ALL,
-            },
-        },
-    } as AppBinding;
 };

--- a/src/bindings/post_menu.ts
+++ b/src/bindings/post_menu.ts
@@ -1,10 +1,9 @@
 import {AppBinding} from 'mattermost-redux/types/apps';
-import {AppExpandLevels} from 'mattermost-redux/constants/apps';
 
-import {Routes, Locations, ZendeskIcon} from '../utils/constants';
 import {isZdAdmin, isZdAgent} from '../utils/utils';
-import {getStaticURL, newPostMenuBindings} from '../utils';
-import {getManifest} from '../manifest';
+import {newPostMenuBindings} from '../utils';
+
+import {getCreateTicketBinding} from './bindings';
 
 import {BindingOptions} from './index';
 
@@ -20,27 +19,9 @@ export const getPostMenuBindings = (options: BindingOptions): AppBinding => {
     // admins and agents can create tickets in Zendesk
     if (options.isConnected) {
         if (isZdAdmin(options.zdUserRole) || isZdAgent(options.zdUserRole)) {
-            bindings.push(openCreateTicketForm(options.mattermostSiteUrl));
+            bindings.push(getCreateTicketBinding(options.mattermostSiteUrl));
         }
     }
     return newPostMenuBindings(bindings);
 };
 
-export const openCreateTicketForm = (mmSiteUrl: string): AppBinding => {
-    return {
-        app_id: getManifest().app_id,
-        label: 'Create Zendesk Ticket',
-        description: 'Create ticket in Zendesk',
-        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
-        location: Locations.Ticket,
-        call: {
-            path: Routes.App.CallPathTicketOpenForm,
-            expand: {
-                post: AppExpandLevels.EXPAND_ALL,
-                acting_user: AppExpandLevels.EXPAND_ALL,
-                acting_user_access_token: AppExpandLevels.EXPAND_ALL,
-                oauth2_user: AppExpandLevels.EXPAND_ALL,
-            },
-        },
-    };
-};

--- a/src/bindings/slash_commands.ts
+++ b/src/bindings/slash_commands.ts
@@ -1,11 +1,10 @@
 import {AppBinding} from 'mattermost-redux/types/apps';
-import {AppExpandLevels} from 'mattermost-redux/constants/apps';
 
-import {Routes, Locations, ZendeskIcon} from '../utils/constants';
-import {getStaticURL, newCommandBindings} from '../utils';
+import {newCommandBindings} from '../utils';
 import {isZdAdmin} from '../utils/utils';
 import {BindingOptions} from 'bindings';
-import {getManifest} from '../manifest';
+
+import {getConnectBinding, getDisconnectBinding, getConfigureBinding, getSubscribeBinding, getHelpBinding, getTargetBinding} from './bindings';
 
 // getCommandBindings returns the users slash command bindings
 export const getCommandBindings = (options: BindingOptions): AppBinding => {
@@ -15,159 +14,30 @@ export const getCommandBindings = (options: BindingOptions): AppBinding => {
     // only show configuration option if admin has not configured the plugin
     if (!options.isConfigured) {
         if (options.isSystemAdmin) {
-            bindings.push(cmdConfigure(mmSiteURL));
-            bindings.push(cmdHelp(mmSiteURL));
+            bindings.push(getConfigureBinding(mmSiteURL));
+            bindings.push(getHelpBinding(mmSiteURL));
             return newCommandBindings(mmSiteURL, bindings);
         }
     }
     if (options.isConnected) {
         // only admins can create triggers and targets in zendesk
         if (isZdAdmin(options.zdUserRole)) {
-            bindings.push(cmdSubscribe(mmSiteURL));
+            bindings.push(getSubscribeBinding(mmSiteURL));
             if (options.isSystemAdmin) {
-                bindings.push(cmdTarget(mmSiteURL));
+                bindings.push(getTargetBinding(mmSiteURL));
             }
         }
-        bindings.push(cmdDisconnect(mmSiteURL));
+        bindings.push(getDisconnectBinding(mmSiteURL));
 
-        // bindings.push(cmdMe(mmSiteURL));
+        // bindings.push(getMeBinding(mmSiteURL));
     } else {
-        bindings.push(cmdConnect(mmSiteURL));
+        bindings.push(getConnectBinding(mmSiteURL));
     }
 
     if (options.isSystemAdmin) {
-        bindings.push(cmdConfigure(mmSiteURL));
+        bindings.push(getConfigureBinding(mmSiteURL));
     }
-    bindings.push(cmdHelp(mmSiteURL));
+    bindings.push(getHelpBinding(mmSiteURL));
     return newCommandBindings(mmSiteURL, bindings);
-};
-
-// CommandBindings class for creating slash command location bindings
-const cmdConnect = (mmSiteUrl: string): AppBinding => {
-    return {
-        app_id: getManifest().app_id,
-        location: Locations.Connect,
-        label: 'connect',
-        description: 'Connect your Zendesk account',
-        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
-        form: {fields: []},
-        call: {
-            expand: {
-                oauth2_app: AppExpandLevels.EXPAND_ALL,
-            },
-            path: Routes.App.BindingPathConnect,
-        },
-    };
-};
-
-const cmdDisconnect = (mmSiteUrl: string): AppBinding => {
-    return {
-        app_id: getManifest().app_id,
-        location: Locations.Disconnect,
-        label: 'disconnect',
-        description: 'Disconnect your Zendesk account',
-        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
-        form: {fields: []},
-        call: {
-            expand: {
-                acting_user_access_token: AppExpandLevels.EXPAND_ALL,
-                oauth2_user: AppExpandLevels.EXPAND_ALL,
-            },
-            path: Routes.App.BindingPathDisconnect,
-        },
-    };
-};
-
-const cmdSubscribe = (mmSiteUrl: string): AppBinding => {
-    return {
-        app_id: getManifest().app_id,
-        location: Locations.Subscribe,
-        label: 'subscribe',
-        description: 'Subscribe notifications to a channel',
-        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
-        form: {fields: []},
-        call: {
-            path: Routes.App.CallPathSubsOpenForm,
-            expand: {
-                acting_user: AppExpandLevels.EXPAND_ALL,
-                admin_access_token: AppExpandLevels.EXPAND_ALL,
-                channel: AppExpandLevels.EXPAND_SUMMARY,
-                acting_user_access_token: AppExpandLevels.EXPAND_ALL,
-                oauth2_user: AppExpandLevels.EXPAND_ALL,
-            },
-        },
-    };
-};
-
-const cmdConfigure = (mmSiteUrl: string): AppBinding => {
-    return {
-        app_id: getManifest().app_id,
-        location: Locations.Configure,
-        label: 'configure',
-        description: 'Configure the installed Zendesk account',
-        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
-        form: {fields: []},
-        call: {
-            path: Routes.App.CallPathConfigOpenForm,
-            expand: {
-                acting_user: AppExpandLevels.EXPAND_ALL,
-                acting_user_access_token: AppExpandLevels.EXPAND_ALL,
-                oauth2_app: AppExpandLevels.EXPAND_ALL,
-                oauth2_user: AppExpandLevels.EXPAND_ALL,
-            },
-        },
-    };
-};
-
-const cmdMe = (mmSiteUrl: string): AppBinding => {
-    return {
-        app_id: getManifest().app_id,
-        location: Locations.Me,
-        label: 'me',
-        description: 'Show Your Zendesk User Info',
-        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
-        form: {fields: []},
-        call: {
-            path: Routes.App.BindingPathMe,
-            expand: {
-                oauth2_user: AppExpandLevels.EXPAND_ALL,
-            },
-        },
-    };
-};
-
-const cmdTarget = (mmSiteUrl: string): AppBinding => {
-    return {
-        app_id: getManifest().app_id,
-        location: Locations.Target,
-        label: 'setup-target',
-        description: 'Setup Zendesk Target',
-        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
-        form: {fields: []},
-        call: {
-            path: Routes.App.BindingPathTargetCreate,
-            expand: {
-                app: AppExpandLevels.EXPAND_ALL,
-                oauth2_user: AppExpandLevels.EXPAND_ALL,
-            },
-        },
-    };
-};
-
-const cmdHelp = (mmSiteUrl: string): AppBinding => {
-    return {
-        app_id: getManifest().app_id,
-        location: Locations.Help,
-        label: 'help',
-        description: 'Show Zendesk Help',
-        icon: getStaticURL(mmSiteUrl, ZendeskIcon),
-        form: {fields: []},
-        call: {
-            path: Routes.App.BindingPathHelp,
-            expand: {
-                acting_user: AppExpandLevels.EXPAND_ALL,
-            },
-        },
-    };
 };
 

--- a/src/forms/subscriptions.ts
+++ b/src/forms/subscriptions.ts
@@ -6,12 +6,12 @@ import {AppSelectOption, AppCallRequest, AppForm, AppField} from 'mattermost-red
 import {AppFieldTypes} from 'mattermost-redux/constants/apps';
 import Client4 from 'mattermost-redux/client/client4.js';
 
-import {CtxExpandedBotAdminActingUserOauth2User, ExpandedChannel} from '../types/apps';
+import {CtxExpandedBotAdminActingUserOauth2User} from '../types/apps';
 import {newZDClient, newMMClient, ZDClient} from '../clients';
 import {ZDClientOptions} from 'clients/zendesk';
 import {MMClientOptions} from 'clients/mattermost';
 import {getStaticURL, Routes} from '../utils';
-import {makeBulletedList, makeSubscriptionOptions, makeChannelOptions, parseTriggerTitle,
+import {makeBulletedList, makeSubscriptionOptions, parseTriggerTitle,
     checkBox, getCheckBoxesFromTriggerDefinition, tryPromiseWithMessage} from '../utils/utils';
 import {ZDTrigger, ZDTriggerCondition, ZDTriggerConditions} from '../utils/ZDTypes';
 import {SubscriptionFields, ZendeskIcon} from '../utils/constants';


### PR DESCRIPTION
#### Summary
This PR moves all bindings into a single shared file `bindings.ts` so that all binding locations can get the same AppBindings objects.  Previously all bindings were defined per location and this caused headaches when making adjustments to the expand field in one binding, but forgetting to make the same changes for another location.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35375