### PR TITLE
Improve error handling

### DIFF
--- a/src/bindings/index.ts
+++ b/src/bindings/index.ts
@@ -15,7 +15,7 @@ export type BindingOptions = {
     zdUserRole: ZDRole,
     mattermostSiteUrl: string
 }
-export async function getBindings(context: CtxExpandedActingUserOauth2AppOauth2User): Promise<AppBinding[]> {
+export function getBindings(context: CtxExpandedActingUserOauth2AppOauth2User): AppBinding[] {
     const bindingOptions = {
         isSystemAdmin: isUserSystemAdmin(context.acting_user),
         isConfigured: isConfigured(context.oauth2),

--- a/src/clients/zendesk.ts
+++ b/src/clients/zendesk.ts
@@ -65,7 +65,7 @@ export type ZDClientOptions = {
 export const newZDClient = async (zdOptions: ZDClientOptions): Promise<ZDClient> => {
     const token = zdOptions.oauth2UserAccessToken;
     if (!token) {
-        throw new Error('Failed to get user access_token');
+        throw new Error('Failed to get oauth2 user access_token');
     }
     const config = await newConfigStore(zdOptions.botAccessToken, zdOptions.mattermostSiteUrl).getValues();
     const remoteUri = config.zd_url + Routes.ZD.APIVersion;

--- a/src/restapi/fBindings.ts
+++ b/src/restapi/fBindings.ts
@@ -4,7 +4,7 @@ import {getBindings} from '../bindings';
 import {CtxExpandedActingUserOauth2AppOauth2User} from '../types/apps';
 import {newOKCallResponseWithData} from '../utils/call_responses';
 
-export async function fBindings(req: Request, res: Response): Promise<void> {
+export function fBindings(req: Request, res: Response): void {
     const context: CtxExpandedActingUserOauth2AppOauth2User = req.body.context;
     const bindings = getBindings(context);
     res.json(newOKCallResponseWithData(bindings));

--- a/src/restapi/fBindings.ts
+++ b/src/restapi/fBindings.ts
@@ -6,6 +6,6 @@ import {newOKCallResponseWithData} from '../utils/call_responses';
 
 export async function fBindings(req: Request, res: Response): Promise<void> {
     const context: CtxExpandedActingUserOauth2AppOauth2User = req.body.context;
-    const bindings = await getBindings(context);
+    const bindings = getBindings(context);
     res.json(newOKCallResponseWithData(bindings));
 }

--- a/src/restapi/fConfig.ts
+++ b/src/restapi/fConfig.ts
@@ -10,15 +10,21 @@ import {baseUrlFromContext} from '../utils/utils';
 
 // fOpenZendeskConfigForm opens a new configuration form
 export async function fOpenZendeskConfigForm(req: Request, res: Response): Promise<void> {
-    const form = await newZendeskConfigForm(req.body);
-    const callResponse = newFormCallResponse(form);
-    res.json(callResponse);
+    try {
+        const form = await newZendeskConfigForm(req.body);
+        res.json(newFormCallResponse(form));
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('Unable to open configuration form: ' + error.message));
+    }
 }
 
 export async function fSubmitOrUpdateZendeskConfigForm(req: Request, res: Response): Promise<void> {
-    const form = await newZendeskConfigForm(req.body);
-    const callResponse = newFormCallResponse(form);
-    res.json(callResponse);
+    try {
+        const form = await newZendeskConfigForm(req.body);
+        res.json(newFormCallResponse(form));
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('Unable to update configuration form: ' + error.message));
+    }
 }
 
 export async function fSubmitOrUpdateZendeskConfigSubmit(req: Request, res: Response): Promise<void> {
@@ -34,6 +40,8 @@ export async function fSubmitOrUpdateZendeskConfigSubmit(req: Request, res: Resp
 
     let callResponse: AppCallResponse = newOKCallResponseWithMarkdown('Successfully updated Zendesk configuration');
     try {
+        // test that any of these awaits will pass the correct error in the catch
+        // message
         const configStore = newConfigStore(context.bot_access_token, context.mattermost_site_url);
         const cValues = await configStore.getValues();
         const targetID = cValues.zd_target_id;
@@ -43,7 +51,7 @@ export async function fSubmitOrUpdateZendeskConfigSubmit(req: Request, res: Resp
         storeValues.zd_oauth_access_token = zdOauth2AccessToken;
         await configStore.storeConfigInfo(storeValues);
     } catch (err) {
-        callResponse = newErrorCallResponseWithMessage(err.message);
+        callResponse = newErrorCallResponseWithMessage('Unable to submit configuration form: ' + err.message);
     }
     res.json(callResponse);
 }

--- a/src/restapi/fConfig.ts
+++ b/src/restapi/fConfig.ts
@@ -40,8 +40,6 @@ export async function fSubmitOrUpdateZendeskConfigSubmit(req: Request, res: Resp
 
     let callResponse: AppCallResponse = newOKCallResponseWithMarkdown('Successfully updated Zendesk configuration');
     try {
-        // test that any of these awaits will pass the correct error in the catch
-        // message
         const configStore = newConfigStore(context.bot_access_token, context.mattermost_site_url);
         const cValues = await configStore.getValues();
         const targetID = cValues.zd_target_id;

--- a/src/restapi/fConfig.ts
+++ b/src/restapi/fConfig.ts
@@ -18,15 +18,6 @@ export async function fOpenZendeskConfigForm(req: Request, res: Response): Promi
     }
 }
 
-export async function fSubmitOrUpdateZendeskConfigForm(req: Request, res: Response): Promise<void> {
-    try {
-        const form = await newZendeskConfigForm(req.body);
-        res.json(newFormCallResponse(form));
-    } catch (error) {
-        res.json(newErrorCallResponseWithMessage('Unable to update configuration form: ' + error.message));
-    }
-}
-
 export async function fSubmitOrUpdateZendeskConfigSubmit(req: Request, res: Response): Promise<void> {
     const call: AppCallRequestWithValues = req.body;
     const context = call.context as CtxExpandedBotActingUserAccessToken;

--- a/src/restapi/fConfig.ts
+++ b/src/restapi/fConfig.ts
@@ -22,15 +22,14 @@ export async function fSubmitOrUpdateZendeskConfigSubmit(req: Request, res: Resp
     const call: AppCallRequestWithValues = req.body;
     const context = call.context as CtxExpandedBotActingUserAccessToken;
     const url = baseUrlFromContext(call.context.mattermost_site_url);
-
     const id = call.values.zd_client_id || '';
     const secret = call.values.zd_client_secret || '';
 
-    const ppClient = newAppsClient(context.acting_user_access_token, url);
-    await ppClient.storeOauth2App(id, secret);
-
     let callResponse: AppCallResponse = newOKCallResponseWithMarkdown('Successfully updated Zendesk configuration');
     try {
+        const ppClient = newAppsClient(context.acting_user_access_token, url);
+        await ppClient.storeOauth2App(id, secret);
+
         const configStore = newConfigStore(context.bot_access_token, context.mattermost_site_url);
         const cValues = await configStore.getValues();
         const targetID = cValues.zd_target_id;

--- a/src/restapi/fConnect.ts
+++ b/src/restapi/fConnect.ts
@@ -78,7 +78,7 @@ export async function fOauth2Complete(req: Request, res: Response): Promise<void
     try {
         user = await zdAuth.code.getToken(zdURL);
     } catch (error) {
-        res.json(newErrorCallResponseWithMessage('fOauth2Complete - Unable to get oauth config: ' + error.message));
+        res.json(newErrorCallResponseWithMessage('fOauth2Complete - Unable to get user token: ' + error.message));
         return;
     }
 
@@ -115,6 +115,7 @@ export async function fOauth2Complete(req: Request, res: Response): Promise<void
         await ppClient.storeOauth2User(storedToken);
     } catch (error) {
         res.json(newErrorCallResponseWithMessage('fOauth2Complete - Unable to store oauth2user: ' + error.message));
+        return;
     }
     const app = newApp(call);
     try {

--- a/src/restapi/fConnect.ts
+++ b/src/restapi/fConnect.ts
@@ -122,6 +122,7 @@ export async function fOauth2Complete(req: Request, res: Response): Promise<void
         await app.createBotDMPost(dmText);
     } catch (error) {
         res.json(newErrorCallResponseWithMessage('fOauth2Complete - Unable to create bot DM post: ' + error.message));
+        return;
     }
     res.json(newOKCallResponse());
 }

--- a/src/restapi/fConnect.ts
+++ b/src/restapi/fConnect.ts
@@ -1,12 +1,12 @@
 import {Request, Response} from 'express';
-import ClientOAuth2 from 'client-oauth2';
+import ClientOAuth2, {Token} from 'client-oauth2';
 import {AppCallResponse} from 'mattermost-redux/types/apps';
 import {AppCallResponseTypes} from 'mattermost-redux/constants/apps';
 
 import {AppCallRequestWithValues, ExpandedOauth2App, CtxExpandedActingUserOauth2AppBot, CtxExpandedBotActingUserOauth2AppOauth2User} from '../types/apps';
 import {ZDClientOptions} from 'clients/zendesk';
-import {newOKCallResponse, newOKCallResponseWithMarkdown} from '../utils/call_responses';
-import {newConfigStore} from '../store';
+import {newOKCallResponse, newOKCallResponseWithMarkdown, newErrorCallResponseWithMessage} from '../utils/call_responses';
+import {newConfigStore, AppConfigStore} from '../store/config';
 import {Routes} from '../utils';
 import {ZDRoles} from '../utils/constants';
 import {newApp} from '../app/app';
@@ -14,7 +14,7 @@ import {newAppsClient, newZDClient} from '../clients';
 import {getOAuthConfig} from '../app/oauth';
 import {StoredOauthUserToken} from 'utils/ZDTypes';
 
-export async function fConnect(req: Request, res: Response): Promise<void> {
+export function fConnect(req: Request, res: Response): void {
     const context: ExpandedOauth2App = req.body.context;
     const url = context.oauth2.connect_url;
     res.json(newOKCallResponseWithMarkdown(`Follow this [link](${url}) to connect Mattermost to your Zendesk Account.`));
@@ -25,7 +25,13 @@ export async function fOauth2Connect(req: Request, res: Response): Promise<void>
     const state = req.body.values.state;
 
     const configStore = newConfigStore(context.bot_access_token, context.mattermost_site_url);
-    const config = await configStore.getValues();
+    let config: AppConfigStore;
+    try {
+        config = await configStore.getValues();
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('fOauth2Connect - Unable to get config store values: ' + error.message));
+        return;
+    }
     const zdHost = config.zd_url;
     const clientID = context.oauth2.client_id;
 
@@ -59,9 +65,23 @@ export async function fOauth2Complete(req: Request, res: Response): Promise<void
         throw new Error('Bad Request: code param not provided');
     }
 
-    const zdAuth = await getOAuthConfig(context);
+    let zdAuth: ClientOAuth2;
+    try {
+        zdAuth = await getOAuthConfig(context);
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('fOauth2Complete - Unable to get oauth config: ' + error.message));
+        return;
+    }
     const zdURL = context.oauth2.complete_url + '?code=' + code;
-    const user = await zdAuth.code.getToken(zdURL);
+
+    let user: Token;
+    try {
+        user = await zdAuth.code.getToken(zdURL);
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('fOauth2Complete - Unable to get oauth config: ' + error.message));
+        return;
+    }
+
     const token: ClientOAuth2.Data = user.data;
     const accessToken: string = token.access_token;
 
@@ -72,7 +92,13 @@ export async function fOauth2Complete(req: Request, res: Response): Promise<void
         mattermostSiteUrl: context.mattermost_site_url,
     };
     const zdClient = await newZDClient(zdOptions);
-    const me = await zdClient.users.me();
+    let me: any;
+    try {
+        me = await zdClient.users.me();
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('fOauth2Complete - Unable to get current zendesk user: ' + error.message));
+        return;
+    }
     let dmText = 'You have successfully connected your Zendesk account!';
     if (me.role !== ZDRoles.admin && me.role !== ZDRoles.agent) {
         dmText += '  This app currently supports Zendesk admin and agent accounts and does not provide any features for end-user accounts.';
@@ -85,8 +111,16 @@ export async function fOauth2Complete(req: Request, res: Response): Promise<void
         token,
         role: me.role,
     };
-    await ppClient.storeOauth2User(storedToken);
+    try {
+        await ppClient.storeOauth2User(storedToken);
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('fOauth2Complete - Unable to store oauth2user: ' + error.message));
+    }
     const app = newApp(call);
-    await app.createBotDMPost(dmText);
+    try {
+        await app.createBotDMPost(dmText);
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('fOauth2Complete - Unable to create bot DM post: ' + error.message));
+    }
     res.json(newOKCallResponse());
 }

--- a/src/restapi/fCreateTicket.ts
+++ b/src/restapi/fCreateTicket.ts
@@ -31,7 +31,8 @@ export async function fSubmitOrUpdateCreateTicketSubmit(req: Request, res: Respo
     const call: AppCallRequest = req.body;
     try {
         const app = newApp(call);
-        res.json(await app.createTicketFromPost());
+        const callResponse = await app.createTicketFromPost();
+        res.json(callResponse);
     } catch (err) {
         res.json(newErrorCallResponseWithMessage('Unable to create ticket from post: ' + err.message));
     }

--- a/src/restapi/fCreateTicket.ts
+++ b/src/restapi/fCreateTicket.ts
@@ -1,34 +1,38 @@
 import {Request, Response} from 'express';
-import {AppCallResponse, AppCallRequest} from 'mattermost-redux/types/apps';
+import {AppCallRequest} from 'mattermost-redux/types/apps';
 
-import {newFormCallResponse, newOKCallResponse, newErrorCallResponseWithMessage} from '../utils/call_responses';
+import {newFormCallResponse, newErrorCallResponseWithMessage} from '../utils/call_responses';
 import {newCreateTicketForm} from '../forms';
 import {newApp} from '../app/app';
 
 // fOpenCreateTicketForm opens a new create ticket form
 export async function fOpenCreateTicketForm(req: Request, res: Response): Promise<void> {
-    const form = await newCreateTicketForm(req.body);
-    const callResponse = newFormCallResponse(form);
-    res.json(callResponse);
+    try {
+        const form = await newCreateTicketForm(req.body);
+        res.json(newFormCallResponse(form));
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('Unable to open create ticket form: ' + error.message));
+    }
 }
 
 // fSubmitOrUpdateCreateTicketForm updates the create ticket form with new values or
 // submits the ticket if submit button is clicked
 export async function fSubmitOrUpdateCreateTicketForm(req: Request, res: Response): Promise<void> {
-    const form = await newCreateTicketForm(req.body);
-    const callResponse = newFormCallResponse(form);
-    res.json(callResponse);
+    try {
+        const form = await newCreateTicketForm(req.body);
+        res.json(newFormCallResponse(form));
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('Unable to update create ticket form: ' + error.message));
+    }
 }
 
 // fSubmitOrUpdateCreateTicketSubmit creates a ticket
 export async function fSubmitOrUpdateCreateTicketSubmit(req: Request, res: Response): Promise<void> {
     const call: AppCallRequest = req.body;
-    let callResponse: AppCallResponse = newOKCallResponse();
     try {
         const app = newApp(call);
-        callResponse = await app.createTicketFromPost();
+        res.json(await app.createTicketFromPost());
     } catch (err) {
-        callResponse = newErrorCallResponseWithMessage(err.message);
+        res.json(newErrorCallResponseWithMessage(err.message));
     }
-    res.json(callResponse);
 }

--- a/src/restapi/fCreateTicket.ts
+++ b/src/restapi/fCreateTicket.ts
@@ -33,6 +33,6 @@ export async function fSubmitOrUpdateCreateTicketSubmit(req: Request, res: Respo
         const app = newApp(call);
         res.json(await app.createTicketFromPost());
     } catch (err) {
-        res.json(newErrorCallResponseWithMessage(err.message));
+        res.json(newErrorCallResponseWithMessage('Unable to create ticket from post: ' + err.message));
     }
 }

--- a/src/restapi/fDisconnect.ts
+++ b/src/restapi/fDisconnect.ts
@@ -4,7 +4,6 @@ import {CtxExpandedBotAdminActingUserOauth2User} from '../types/apps';
 import {newOKCallResponseWithMarkdown, newErrorCallResponseWithMessage} from '../utils/call_responses';
 import {newZDClient, newAppsClient} from '../clients';
 import {ZDClientOptions} from 'clients/zendesk';
-import {tryPromiseWithMessage} from '../utils';
 import {ZDTokensResponse} from '../utils/ZDTypes';
 import {newConfigStore, AppConfigStore} from '../store/config';
 

--- a/src/restapi/fDisconnect.ts
+++ b/src/restapi/fDisconnect.ts
@@ -1,12 +1,12 @@
 import {Request, Response} from 'express';
 
 import {CtxExpandedBotAdminActingUserOauth2User} from '../types/apps';
-import {newOKCallResponseWithMarkdown} from '../utils/call_responses';
+import {newOKCallResponseWithMarkdown, newErrorCallResponseWithMessage} from '../utils/call_responses';
 import {newZDClient, newAppsClient} from '../clients';
 import {ZDClientOptions} from 'clients/zendesk';
 import {tryPromiseWithMessage} from '../utils';
 import {ZDTokensResponse} from '../utils/ZDTypes';
-import {newConfigStore} from '../store';
+import {newConfigStore, AppConfigStore} from '../store/config';
 
 export async function fDisconnect(req: Request, res: Response): Promise<void> {
     const context: CtxExpandedBotAdminActingUserOauth2User = req.body.context;
@@ -17,7 +17,15 @@ export async function fDisconnect(req: Request, res: Response): Promise<void> {
     };
 
     // get the saved service account config zendesk access_token
-    const config = await newConfigStore(context.bot_access_token, context.mattermost_site_url).getValues();
+    const configStore = newConfigStore(context.bot_access_token, context.mattermost_site_url);
+    let config: AppConfigStore;
+    try {
+        config = await configStore.getValues();
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('fDisconnect - Unable to get config store values: ' + error.message));
+        return;
+    }
+
     const configOauthToken = config.zd_oauth_access_token;
     const text = 'This mattermost account is connected via oauth2 to Zendesk for subscription functionality and cannot be disconnected until the access token is updated to a new user access token. Please have another connected Mattermost System Admin user with Zendesk Admin privileges run `/zendesk setup-target` to update the access_token';
     if (context.oauth2.user.token.access_token === configOauthToken) {
@@ -26,8 +34,13 @@ export async function fDisconnect(req: Request, res: Response): Promise<void> {
     }
 
     const zdClient = await newZDClient(zdOptions);
-    const oauthReq = zdClient.oauthtokens.list();
-    const tokens: ZDTokensResponse = await tryPromiseWithMessage(oauthReq, 'failed to get oauth tokens');
+    let tokens: ZDTokensResponse;
+    try {
+        tokens = await zdClient.oauthtokens.list();
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('fDisconnect - Unable to list zendesk oauth tokens: ' + error.message));
+        return;
+    }
 
     // get the token ID
     const tokenID = getUserTokenID(zdOptions.oauth2UserAccessToken, tokens);
@@ -37,8 +50,11 @@ export async function fDisconnect(req: Request, res: Response): Promise<void> {
     await ppClient.storeOauth2User({token: {}, role: ''});
 
     // delete the zendesk user oauth token
-    const deleteReq = zdClient.oauthtokens.revoke(tokenID);
-    await tryPromiseWithMessage(deleteReq, 'failed to revoke acting user token');
+    try {
+        await zdClient.oauthtokens.revoke(tokenID);
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('fDisconnect - failed to revoke acting user token'));
+    }
 
     res.json(newOKCallResponseWithMarkdown('You have disconnected your Zendesk account'));
 }

--- a/src/restapi/fDisconnect.ts
+++ b/src/restapi/fDisconnect.ts
@@ -53,6 +53,7 @@ export async function fDisconnect(req: Request, res: Response): Promise<void> {
         await zdClient.oauthtokens.revoke(tokenID);
     } catch (error) {
         res.json(newErrorCallResponseWithMessage('fDisconnect - failed to revoke acting user token'));
+        return;
     }
 
     res.json(newOKCallResponseWithMarkdown('You have disconnected your Zendesk account'));

--- a/src/restapi/fSubscriptions.ts
+++ b/src/restapi/fSubscriptions.ts
@@ -38,7 +38,8 @@ export async function fSubmitOrUpdateSubscriptionsForm(req: Request, res: Respon
 export async function fSubmitOrUpdateSubscriptionsSubmit(req: Request, res: Response): Promise<void> {
     try {
         const app = newApp(req.body);
-        res.json(await app.createZDSubscription());
+        const callResponse = await app.createZDSubscription();
+        res.json(callResponse);
     } catch (error) {
         res.json(newErrorCallResponseWithMessage('Unable to create subscription: ' + error.message));
     }

--- a/src/restapi/fSubscriptions.ts
+++ b/src/restapi/fSubscriptions.ts
@@ -14,6 +14,7 @@ export async function fOpenSubscriptionsForm(req: Request, res: Response): Promi
     if (!webhookConfigured(cValues)) {
         const msg = 'Subscriptions cannot be created before the Zendesk Target is configured.  Please contact your Mattermost admin.';
         res.json(newOKCallResponseWithMarkdown(msg));
+        return;
     }
     try {
         const form = await newSubscriptionsForm(req.body);

--- a/src/restapi/fSubscriptions.ts
+++ b/src/restapi/fSubscriptions.ts
@@ -36,6 +36,10 @@ export async function fSubmitOrUpdateSubscriptionsForm(req: Request, res: Respon
 }
 
 export async function fSubmitOrUpdateSubscriptionsSubmit(req: Request, res: Response): Promise<void> {
-    const app = newApp(req.body);
-    res.json(await app.createZDSubscription());
+    try {
+        const app = newApp(req.body);
+        res.json(await app.createZDSubscription());
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('Unable to create subscription: ' + error.message));
+    }
 }

--- a/src/restapi/fSubscriptions.ts
+++ b/src/restapi/fSubscriptions.ts
@@ -1,6 +1,6 @@
 import {Request, Response} from 'express';
 
-import {newFormCallResponse, newOKCallResponseWithMarkdown} from '../utils/call_responses';
+import {newFormCallResponse, newOKCallResponseWithMarkdown, newErrorCallResponseWithMessage} from '../utils/call_responses';
 import {newSubscriptionsForm} from '../forms';
 import {newApp} from '../app/app';
 import {webhookConfigured} from '../utils/utils';
@@ -14,24 +14,27 @@ export async function fOpenSubscriptionsForm(req: Request, res: Response): Promi
     if (!webhookConfigured(cValues)) {
         const msg = 'Subscriptions cannot be created before the Zendesk Target is configured.  Please contact your Mattermost admin.';
         res.json(newOKCallResponseWithMarkdown(msg));
-        return;
     }
-
-    const form = await newSubscriptionsForm(req.body);
-    const callResponse = newFormCallResponse(form);
-    res.json(callResponse);
+    try {
+        const form = await newSubscriptionsForm(req.body);
+        res.json(newFormCallResponse(form));
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('Unable to open subscriptions form: ' + error.message));
+    }
 }
 
 // SubmitOrUpdateSubscriptionsForm updates the subscriptions form with new values or
 // submits the form if submit button is clicked
 export async function fSubmitOrUpdateSubscriptionsForm(req: Request, res: Response): Promise<void> {
-    const form = await newSubscriptionsForm(req.body);
-    const callResponse = newFormCallResponse(form);
-    res.json(callResponse);
+    try {
+        const form = await newSubscriptionsForm(req.body);
+        res.json(newFormCallResponse(form));
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('Unable to update subscriptions form: ' + error.message));
+    }
 }
 
 export async function fSubmitOrUpdateSubscriptionsSubmit(req: Request, res: Response): Promise<void> {
     const app = newApp(req.body);
-    const callResponse = await app.createZDSubscription();
-    res.json(callResponse);
+    res.json(await app.createZDSubscription());
 }

--- a/src/restapi/fTarget.ts
+++ b/src/restapi/fTarget.ts
@@ -6,7 +6,7 @@ import {webhookConfigured, isZdAdmin} from '../utils/utils';
 import {newZDClient, ZDClient} from '../clients';
 import {ZDClientOptions} from 'clients/zendesk';
 import {newConfigStore} from '../store';
-import {newOKCallResponseWithMarkdown} from '../utils/call_responses';
+import {newOKCallResponseWithMarkdown, newErrorCallResponseWithMessage} from '../utils/call_responses';
 import {CtxExpandedBotAppActingUserOauth2AppOauth2User} from 'types/apps';
 
 export async function fCreateTarget(req: Request, res: Response): Promise<void> {
@@ -17,9 +17,12 @@ export async function fCreateTarget(req: Request, res: Response): Promise<void> 
         mattermostSiteUrl: context.mattermost_site_url,
     };
     const zdClient = await newZDClient(zdOptions);
-
-    const text = await updateOrCreateTarget(zdClient, context);
-    res.json(newOKCallResponseWithMarkdown(text));
+    try {
+        const text = await updateOrCreateTarget(zdClient, context);
+        res.json(newOKCallResponseWithMarkdown(text));
+    } catch (error) {
+        res.json(newErrorCallResponseWithMessage('Unable to create target: ' + error.message));
+    }
 }
 
 // updateOrCreateTarget creates a target or updates an the exising target

--- a/src/restapi/mm_routes.ts
+++ b/src/restapi/mm_routes.ts
@@ -6,7 +6,7 @@ import {fBindings} from './fBindings';
 import {fConnect, fOauth2Connect, fOauth2Complete} from './fConnect';
 import {fOpenCreateTicketForm, fSubmitOrUpdateCreateTicketForm, fSubmitOrUpdateCreateTicketSubmit} from './fCreateTicket';
 import {fOpenSubscriptionsForm, fSubmitOrUpdateSubscriptionsForm, fSubmitOrUpdateSubscriptionsSubmit} from './fSubscriptions';
-import {fOpenZendeskConfigForm, fSubmitOrUpdateZendeskConfigForm, fSubmitOrUpdateZendeskConfigSubmit} from './fConfig';
+import {fOpenZendeskConfigForm, fSubmitOrUpdateZendeskConfigSubmit} from './fConfig';
 import {fHandleSubcribeNotification} from './fIncomingWebhooks';
 import {fDisconnect} from './fDisconnect';
 import {fHelp} from './fHelp';


### PR DESCRIPTION
## Summary
This PR improves error handling throughout the app.  Specifically, the restapi call functions should provide better output to the user when a command fails. This includes scrubbing the following call function files.

This PR only adds the validation for API calls and does not include the call request error checking. There is a separate ticket for that issue https://mattermost.atlassian.net/browse/MM-35166

### These functions do not include any API calls that would require error handling. They will need context checking which will be in another PR

- [x] fManifest.ts - does not include any API calls. Only serves the manifest.json
- [x] fInstall.ts - does not include any API calls. Only responds with markdown call response.
- [x] fHelp.ts - does not include any API calls. It Only parses the call context.
- [x] fBindings.ts
 
### This function is not actually used at the moment.

- [x] fMe.ts - Error handling will be added when the is function is implemented

### These functions make API calls that needed error handling

- [x] fCreateTicket.ts
- [x] fConnect.ts
	- [x] `fConnect()` - does not make any API calls and only responds with markdown callResponse
	- [x] `fOauth2Connect()`
	- [x] `fOauth2Complete()`
- [x] fDisconnect.ts
- [x] fSubscriptions.ts
- [x] fConfig.ts
- [x] fTarget.ts
- [x] fIncomingWebhooks.ts - errors are thrown and logged. no user facing messages

## Ticket Link

- [ ] https://mattermost.atlassian.net/browse/MM-35461 - MM Apps - Improve message when user selects a stale binding that is no longer available
- [ ] https://mattermost.atlassian.net/browse/MM-33555 - Error handling