### PR TITLE
[MM-33762] Use markdown instead of posting in text textarea box

### DIFF
--- a/src/app/triggerFromForm.ts
+++ b/src/app/triggerFromForm.ts
@@ -70,11 +70,13 @@ export class TriggerFromFormImpl implements TriggerFromFrom {
     }
 
     addTitle(): void {
-        let title = SubscriptionFields.PrefixTriggersTitle;
-        title += SubscriptionFields.RegexTriggerInstance + this.context.mattermost_site_url;
-        title += SubscriptionFields.RegexTriggerTeamID + this.context.team_id;
-        title += SubscriptionFields.RegexTriggerChannelID + this.context.channel_id;
-        title += ' ' + this.values[SubscriptionFields.SubTextName];
+        const title = [
+            SubscriptionFields.PrefixTriggersTitle,
+            SubscriptionFields.RegexTriggerInstance + this.context.mattermost_site_url,
+            SubscriptionFields.RegexTriggerTeamID + this.context.team_id,
+            SubscriptionFields.RegexTriggerChannelID + this.context.channel_id,
+            ' ' + this.values[SubscriptionFields.SubTextName],
+        ].join('');
         this.addField('title', title);
     }
 

--- a/src/forms/subscriptions.ts
+++ b/src/forms/subscriptions.ts
@@ -113,13 +113,16 @@ class FormFields extends BaseFormFields {
     async getTriggers(): Promise<any> {
         // modified node-zendesk to allow hitting triggers/search api
         // returns all triggers for all channels and teams
-        let search = SubscriptionFields.PrefixTriggersTitle;
-        search += SubscriptionFields.RegexTriggerInstance;
-        search += this.call.context.mattermost_site_url;
-        search += SubscriptionFields.RegexTriggerTeamID;
-        search += this.call.context.team_id;
-        search += SubscriptionFields.RegexTriggerChannelID;
-        search += this.call.context.channel_id;
+        const search = [
+            SubscriptionFields.PrefixTriggersTitle,
+            SubscriptionFields.RegexTriggerInstance,
+            this.call.context.mattermost_site_url,
+            SubscriptionFields.RegexTriggerTeamID,
+            this.call.context.team_id,
+            SubscriptionFields.RegexTriggerChannelID,
+            this.call.context.channel_id,
+        ].join('');
+
         const client = this.zdClient as ZDClient;
         const searchReq = client.triggers.search(search) || '';
         return tryPromiseWithMessage(searchReq, 'Failed to fetch triggers');
@@ -274,10 +277,13 @@ class FormFields extends BaseFormFields {
     // addErrorMessageField adds a text field with a message when a trigger has
     // conditions not supported by the app
     addErrorMessageField(link: string): void {
-        let md = 'The following condition fields are not currently supported by the app. Please visit the trigger link to modify the conditions for this subscription\n';
-        md += makeBulletedList('Unsupported Fields', this.unsupportedFields) + '\n';
-        md += makeBulletedList('Unsupported Field Operators', this.unsupportedOperators) + '\n';
-        md += '##### Trigger Link\n' + link;
+        const md = [
+            'The following condition fields are not currently supported by the app. Please visit the trigger link to modify the conditions for this subscription',
+            makeBulletedList('Unsupported Fields', this.unsupportedFields),
+            makeBulletedList('Unsupported Field Operators', this.unsupportedOperators),
+            '##### Trigger Link',
+            link,
+        ].join('\n');
 
         const f: AppField = {
             name: SubscriptionFields.UnsupportedFieldsTextName,

--- a/src/forms/subscriptions.ts
+++ b/src/forms/subscriptions.ts
@@ -241,7 +241,7 @@ class FormFields extends BaseFormFields {
         if (this.unsupportedFields.length !== 0 || this.unsupportedOperators.length !== 0) {
             const host = this.zdHost;
             const trigger = this.getSelectedSubTrigger();
-            const url = `${host}agent/admin/triggers/${trigger.id}`;
+            const url = `${host}/agent/admin/triggers/${trigger.id}`;
             this.addErrorMessageField(url);
             return false;
         }

--- a/src/forms/subscriptions.ts
+++ b/src/forms/subscriptions.ts
@@ -241,7 +241,7 @@ class FormFields extends BaseFormFields {
         if (this.unsupportedFields.length !== 0 || this.unsupportedOperators.length !== 0) {
             const host = this.zdHost;
             const trigger = this.getSelectedSubTrigger();
-            const url = `${host}/agent/admin/triggers/${trigger.id}`;
+            const url = `${host}agent/admin/triggers/${trigger.id}`;
             this.addErrorMessageField(url);
             return false;
         }
@@ -274,20 +274,15 @@ class FormFields extends BaseFormFields {
     // addErrorMessageField adds a text field with a message when a trigger has
     // conditions not supported by the app
     addErrorMessageField(link: string): void {
-        let text = 'The following condition fields are not currently supported by the app. Please visit the trigger link to modify the conditions for this subscription';
-        text += '\n\n';
-        text += makeBulletedList('Unsupported Fields', this.unsupportedFields);
-        text += '\n\n';
-        text += makeBulletedList('Unsupported Field Operators', this.unsupportedOperators);
-        text += '\n\n' + link;
+        let md = 'The following condition fields are not currently supported by the app. Please visit the trigger link to modify the conditions for this subscription\n';
+        md += makeBulletedList('Unsupported Fields', this.unsupportedFields) + '\n';
+        md += makeBulletedList('Unsupported Field Operators', this.unsupportedOperators) + '\n';
+        md += '##### Trigger Link\n' + link;
 
         const f: AppField = {
             name: SubscriptionFields.UnsupportedFieldsTextName,
-            type: AppFieldTypes.TEXT,
-            subtype: 'textarea',
-            label: 'Optional message',
-            value: text,
-            readonly: true,
+            type: 'markdown',
+            description: md,
         };
 
         this.builder.addField(f);

--- a/src/restapi/fHelp.ts
+++ b/src/restapi/fHelp.ts
@@ -12,7 +12,7 @@ export async function fHelp(req: Request, res: Response): Promise<void> {
         getHeader(),
         getCommands(req.body),
         getPostText(),
-    ].join('\n');
+    ].join('');
     res.json(newOKCallResponseWithMarkdown(helpText));
 }
 

--- a/src/restapi/fHelp.ts
+++ b/src/restapi/fHelp.ts
@@ -31,30 +31,30 @@ function getCommands(call: AppCallRequest): string {
 }
 
 function getUserCommands(): string {
-    return [
+    return joinLines(
         h5('User Commands'),
         addBulletSlashCommand('connect'),
         addBulletSlashCommand('disconnect'),
         addBulletSlashCommand('help'),
-    ].join('\n') + '\n';
+    ) + '\n';
 }
 
 function getAdminCommands(): string {
-    return [
+    return joinLines(
         h5('System Admin Commands'),
         addBulletSlashCommand('configure'),
         addBulletSlashCommand('setup-target'),
         addBulletSlashCommand('subscribe'),
-    ].join('\n') + '\n';
+    ) + '\n';
 }
 
 function getPostText(): string {
-    return [
+    return joinLines(
         h5('Post Menu Options'),
-        'click the (...) on a post\n',
+        textLine('click the (...) on a post'),
         addBullet('Create Zendesk Ticket'),
         addBullet('Zendesk Subscriptions'),
-    ].join('\n') + '\n';
+    ) + '\n';
 }
 
 function addBullet(text: string): string {
@@ -71,4 +71,12 @@ function h5(text: string): string {
 
 function h4(text: string): string {
     return `#### ${text}\n`;
+}
+
+function textLine(text: string): string {
+    return `${text}\n`;
+}
+
+function joinLines(...lines: string[]): string {
+    return lines.join('\n');
 }

--- a/src/restapi/fHelp.ts
+++ b/src/restapi/fHelp.ts
@@ -8,9 +8,11 @@ import {CommandTrigger} from '../utils/constants';
 import {isUserSystemAdmin} from '../utils';
 
 export async function fHelp(req: Request, res: Response): Promise<void> {
-    let helpText = getHeader();
-    helpText += getCommands(req.body);
-    helpText += getPostText();
+    const helpText = [
+        getHeader(),
+        getCommands(req.body),
+        getPostText(),
+    ].join('\n');
     res.json(newOKCallResponseWithMarkdown(helpText));
 }
 
@@ -29,35 +31,38 @@ function getCommands(call: AppCallRequest): string {
 }
 
 function getUserCommands(): string {
-    let text = h5('User Commands');
-    text += addBulletSlashCommand('connect');
-    text += addBulletSlashCommand('disconnect');
-    text += addBulletSlashCommand('help');
-    return text;
+    return [
+        h5('User Commands'),
+        addBulletSlashCommand('connect'),
+        addBulletSlashCommand('disconnect'),
+        addBulletSlashCommand('help'),
+    ].join('\n') + '\n';
 }
 
 function getAdminCommands(): string {
-    let text = h5('System Admin Commands');
-    text += addBulletSlashCommand('configure');
-    text += addBulletSlashCommand('setup-target');
-    text += addBulletSlashCommand('subscribe');
-    return text;
+    return [
+        h5('System Admin Commands'),
+        addBulletSlashCommand('configure'),
+        addBulletSlashCommand('setup-target'),
+        addBulletSlashCommand('subscribe'),
+    ].join('\n') + '\n';
 }
 
 function getPostText(): string {
-    let text = h5('Post Menu Options');
-    text += 'click the (...) on a post\n';
-    text += addBullet('Create Zendesk Ticket');
-    text += addBullet('Zendesk Subscriptions');
-    return text;
+    return [
+        h5('Post Menu Options'),
+        'click the (...) on a post\n',
+        addBullet('Create Zendesk Ticket'),
+        addBullet('Zendesk Subscriptions'),
+    ].join('\n') + '\n';
 }
 
 function addBullet(text: string): string {
-    return `* ${text}\n`;
+    return `* ${text}`;
 }
 
 function addBulletSlashCommand(text: string): string {
-    return `* \`/${CommandTrigger} ${text}\`\n`;
+    return `* \`/${CommandTrigger} ${text}\``;
 }
 
 function h5(text: string): string {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -96,7 +96,7 @@ export function baseUrlFromContext(mattermostSiteUrl: string): string {
 export function makeBulletedList(pretext: string, items: string[]): string {
     let text = '* ' + items.join('\n* ');
     if (pretext) {
-        text = `####  ${pretext}\n` + text;
+        text = `####  ${pretext}\n${text}`;
     }
     return text;
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -96,7 +96,7 @@ export function baseUrlFromContext(mattermostSiteUrl: string): string {
 export function makeBulletedList(pretext: string, items: string[]): string {
     let text = '* ' + items.join('\n* ');
     if (pretext) {
-        text = `###  ${pretext}\n` + text;
+        text = `####  ${pretext}\n` + text;
     }
     return text;
 }


### PR DESCRIPTION
#### Summary
This PR makes use of field-level Markdown. The message used a textbox to show the message, but now uses markdown which allows formatting and hyperlinking the trigger link.

![image](https://user-images.githubusercontent.com/7575921/125125647-80d8cf80-e0bf-11eb-9bbf-726812c5c781.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33762