### PR TITLE
remove trailing slash if one is added to the end of the zd url

### DIFF
--- a/src/restapi/fConfig.ts
+++ b/src/restapi/fConfig.ts
@@ -35,6 +35,7 @@ export async function fSubmitOrUpdateZendeskConfigSubmit(req: Request, res: Resp
         const targetID = cValues.zd_target_id;
         const zdOauth2AccessToken = cValues.zd_oauth_access_token;
         const storeValues = call.values as AppConfigStore;
+        storeValues.zd_url = storeValues.zd_url.replace(/\/$/, '');
         storeValues.zd_target_id = targetID;
         storeValues.zd_oauth_access_token = zdOauth2AccessToken;
         await configStore.storeConfigInfo(storeValues);

--- a/src/restapi/fConfig.ts
+++ b/src/restapi/fConfig.ts
@@ -36,7 +36,7 @@ export async function fSubmitOrUpdateZendeskConfigSubmit(req: Request, res: Resp
         const targetID = cValues.zd_target_id;
         const zdOauth2AccessToken = cValues.zd_oauth_access_token;
         const storeValues = call.values as AppConfigStore;
-        storeValues.zd_url = storeValues.zd_url.replace(/\/+$/, '');
+        storeValues.zd_url = storeValues.zd_url.replace(/\/$|(?<!\/)\/+$/, '');
 
         try {
             await verifyUrl(storeValues.zd_url);

--- a/src/restapi/fConfig.ts
+++ b/src/restapi/fConfig.ts
@@ -35,7 +35,7 @@ export async function fSubmitOrUpdateZendeskConfigSubmit(req: Request, res: Resp
         const targetID = cValues.zd_target_id;
         const zdOauth2AccessToken = cValues.zd_oauth_access_token;
         const storeValues = call.values as AppConfigStore;
-        storeValues.zd_url = storeValues.zd_url.replace(/\/$/, '');
+        storeValues.zd_url = storeValues.zd_url.replace(/\/+$/, '');
         storeValues.zd_target_id = targetID;
         storeValues.zd_oauth_access_token = zdOauth2AccessToken;
         await configStore.storeConfigInfo(storeValues);

--- a/src/restapi/fConfig.ts
+++ b/src/restapi/fConfig.ts
@@ -35,6 +35,13 @@ export async function fSubmitOrUpdateZendeskConfigSubmit(req: Request, res: Resp
         const cValues = await configStore.getValues();
         const targetID = cValues.zd_target_id;
         const zdOauth2AccessToken = cValues.zd_oauth_access_token;
+
+        // Using a simple /\/+$/ fails CodeQL check - Polynomial regular
+        // expression used on uncontrolled data. The solution is to utilize the
+        // negative lookbehind pattern match. Matches when the previous
+        // character is not a forward slash, then any number of slashes, and
+        // and EOL.
+        // https://codeql.github.com/codeql-query-help/javascript/js-polynomial-redos/#
         const storeValues = call.values as AppConfigStore;
         storeValues.zd_url = storeValues.zd_url.replace(/\/$|(?<!\/)\/+$/, '');
 
@@ -56,7 +63,7 @@ export async function fSubmitOrUpdateZendeskConfigSubmit(req: Request, res: Resp
 }
 
 const verifyUrl = async (url: string) => {
-    const verifyURL = url + Routes.ZD.AccessURI;
+    const verifyURL = '`' + url + Routes.ZD.AccessURI + '`';
     try {
         const resp = await fetch(verifyURL, {method: 'post'});
         if (!resp.ok) {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -21,6 +21,7 @@ const ZDPaths = {
     OAuthAuthorizationURI: '/oauth/authorizations/new',
     OAuthAccessTokenURI: '/oauth/tokens',
     TicketPathPrefix: '/agent/tickets',
+    AccessURI: '/access/unauthenticated',
     APIVersion: '/api/v2',
 };
 


### PR DESCRIPTION
#### Summary
When a user adds the ZD URL in the configuration modal remove the trailing `/` if one exists.  If the ZD link is of the form `http://mm.zendesk.com//agent/tickets/123` (note the double slash) the link will not resolve correctly when clicked.

This PR removes a trailing slash before saving the configuration values to the KV store.

The PR also checks the Zendesk URL is valid and returns an error if the link is not
![image](https://user-images.githubusercontent.com/7575921/128562885-9f989d67-65ff-49c1-b261-5049b3a84644.png)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36946