### PR TITLE
[MM-35339] Subscription names should be unique per channel

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -161,25 +161,30 @@ class AppImpl implements App {
         return newOKCallResponseWithMarkdown(msg);
     }
 
-    validateSubNameIsUnique = (subName: string): boolean => {
-        const state = this.call.state;
+    validateSubNameIsUnique = (proposedSubName: string): boolean => {
+        // state contains the list of saved subscriptions in Zendesk
+        const zdSubs = this.call.state;
         const values = this.call.values;
 
-        // if matching subname does not exist in state, subname is unique
-        const subFound = state.find((option: AppSelectOption) => option.label === subName);
+        // label value of the selected dropdown subscription
+        const selectedSubName = values?.[SubscriptionFields.SubSelectName].label;
+
+        // if proposed subname does not exist in existing ZD subs, subname is unique
+        const subFound = zdSubs.find((option: AppSelectOption) => option.label === proposedSubName);
         if (!subFound) {
             return true;
         }
 
-        const subOptions = state.filter((option: AppSelectOption) => option.label === subName);
-        const subSelectLabel = values?.[SubscriptionFields.SubSelectName].label;
+        // matchingSubs is an array of existing ZD subs that match the proposed new subName
+        const matchingSubs = zdSubs.filter((option: AppSelectOption) => option.label === proposedSubName);
+        const numMatchingSubs = matchingSubs.length;
 
         // if changing the subName of an existing subscription, ensure new name does not exist
-        if (subSelectLabel !== subName) {
-            return subOptions.length === 0;
+        if (selectedSubName !== proposedSubName) {
+            return numMatchingSubs === 0;
         }
 
-        return subOptions.length <= 1;
+        return numMatchingSubs <= 1;
     }
 
     createActingUserPost = async (message: string): Promise<void> => {

--- a/src/forms/subscriptions.ts
+++ b/src/forms/subscriptions.ts
@@ -40,6 +40,7 @@ export async function newSubscriptionsForm(call: AppCallRequest): Promise<AppFor
     const formFields = new FormFields(call, zdClient, mmClient, zdHost);
     const fields = await formFields.getSubscriptionFields();
 
+    const subOptions = fields.find((field) => field.name === SubscriptionFields.SubSelectName);
     const form: AppForm = {
         title: 'Create or Edit Zendesk Subscriptions',
         header: 'Create or edit channel subscriptions to Zendesk notifications',
@@ -48,6 +49,7 @@ export async function newSubscriptionsForm(call: AppCallRequest): Promise<AppFor
         fields,
         call: {
             path: Routes.App.CallPathSubsSubmitOrUpdateForm,
+            state: subOptions.options,
         },
     };
     return form;
@@ -110,7 +112,7 @@ class FormFields extends BaseFormFields {
     }
 
     // getTriggers gets all the team triggers saved in Zendesk via the ZD client
-    async getTriggers(): Promise<any> {
+    async getTriggers(): Promise<ZDTrigger[]> {
         // modified node-zendesk to allow hitting triggers/search api
         // returns all triggers for all channels and teams
         const search = [

--- a/src/forms/subscriptions.ts
+++ b/src/forms/subscriptions.ts
@@ -49,7 +49,7 @@ export async function newSubscriptionsForm(call: AppCallRequest): Promise<AppFor
         fields,
         call: {
             path: Routes.App.CallPathSubsSubmitOrUpdateForm,
-            state: subOptions.options,
+            state: subOptions?.options,
         },
     };
     return form;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -4,7 +4,6 @@ import {Channel} from 'mattermost-redux/types/channels';
 import {UserProfile} from 'mattermost-redux/types/users';
 
 import {Oauth2App} from '../types/apps';
-import {getManifest} from '../manifest';
 import {AppConfigStore} from '../store/config';
 
 import {SubscriptionFields, ZDRoles} from './constants';


### PR DESCRIPTION
#### Summary
This PR adds validation that a subscription name is unique before Updating or Creating a new subscription. 

The subs options for a channel are passed as state so that a zendesk API call does not need to be called more than once, when the modal is initially opened.

The validation message displays an error when the subscription name is already being used and must be changed by the user.

![image](https://user-images.githubusercontent.com/7575921/126412587-49a4267f-d0a6-4269-991d-9d1bd1bf6c6e.png)

#### Testing

I tested the following:

##### 1. user had previously saved subscriptions with the same name (ex. `subA` and `subA`)
* save some subscriptions that have the same name  (before using this PR, because this PR prevents this from happening)
  * (ex. `subA` and `subA`)
* using this PR branch, select one of the `subA` subscriptions from the dropdown. 
* when the save button is clicked, the message will appear, informing the user they need to edit the name
* change the name and save
* verify subscription has been updated and the name changed.

Note: this is a case that might occur if someone has already created subscriptions with the same name. The subscriptions will work as is but the user will be asked to rename a sub if this case occurs and while trying to update.

##### 2. user creates a new subscription
* no change - subscription created

##### 3. user tries changing the name of a subscription to another existing subscription
* setup - subA and subB exist
* subA is selected in the dropdown
* subA name changed to subB and click save
* field error should show

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35339