### PR TITLE
[MM-35357] Oauth complete - use access_token from AppCall

### DIFF
--- a/src/restapi/fConnect.ts
+++ b/src/restapi/fConnect.ts
@@ -53,12 +53,6 @@ export async function fOauth2Connect(req: Request, res: Response): Promise<void>
 export async function fOauth2Complete(req: Request, res: Response): Promise<void> {
     const call: AppCallRequestWithValues = req.body;
     const context: CtxExpandedBotActingUserOauth2AppOauth2User = req.body.context;
-    context.oauth2.user = {
-        token: {
-            access_token: '',
-        },
-        role: '',
-    };
 
     const code = call.values.code;
     if (code === '') {


### PR DESCRIPTION
#### Summary
Before this PR (https://github.com/mattermost/mattermost-plugin-apps/pull/175) the context did not include an expanded `oauth2.user` which has a `nil` `token` value.  The short-term fix was to add a `nil` value expanded `oauth2` to the context inside the Zendesk app.  

Which the properly expanded oauth2user context, this is no longer needed and can be removed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35357