### PR TITLE
[MM-35420] add readonly prop to the AppField

### DIFF
--- a/src/utils/helper_classes/fields/fields_builder.ts
+++ b/src/utils/helper_classes/fields/fields_builder.ts
@@ -63,6 +63,7 @@ class FieldsBuilderImpl implements FieldsBuilder {
             max_length: f.max_length || this.defaultMaxLength,
             refresh: f.refresh,
             is_required: f.is_required,
+            readonly: f.readonly,
 
             // if field is provided by caller, use that value
             value,


### PR DESCRIPTION
#### Summary
This PR adds the optional readonly field to the `fieldsBuilder` class so that a field can be set to readonly.

The Apps Plugin has this capability, but the Zendesk app was not sending the bool value.

The Mattermost message field when creating a ticket will be readonly after this change.
![image](https://user-images.githubusercontent.com/7575921/126500396-30bd2bf5-1407-4807-8a6c-f0169685cae4.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35420