### PR TITLE
[MM-35388] don't include inactive triggers in the subscription dropdown list

### DIFF
--- a/src/forms/subscriptions.ts
+++ b/src/forms/subscriptions.ts
@@ -154,6 +154,10 @@ class FormFields extends BaseFormFields {
     //                array of triggers for the current team
     addChannelTrigger(triggers: ZDTrigger[]): void {
         for (const trigger of triggers) {
+            // do not include inactive triggers
+            if (!trigger.active) {
+                continue;
+            }
             const parsedTitle = parseTriggerTitle(trigger.title);
             const channelID = parsedTitle.channelID;
             if (!this.triggers[channelID]) {

--- a/src/utils/ZDTypes.ts
+++ b/src/utils/ZDTypes.ts
@@ -17,6 +17,7 @@ export type ZDTrigger = {
     url: string
     id: number
     title: string
+    active: boolean
     conditions: ZDTriggerConditions
 }
 


### PR DESCRIPTION
#### Summary
When building the list of triggers (subscriptions) for the dropdown list, do not include `inactive` triggers in the list. 

Having an inactive trigger will not be done through the zendesk app. The zendesk app only adds/deletes triggers, but a user can go into zendesk and inactivate a trigger.

Testing:
* add a subscription through the zendesk app.
* observe it shows in the dropdown when open the subscription modal again
* close the modal
* in Zendesk, market the trigger inactive
* open the subscriptions modal and observe the trigger no longer shows up in the list.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35388