### PR TITLE
MM-37568] Update README prerequisites and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository is licensed under the [Apache 2.0 License](https://github.com/ma
 ## Table of Contents
 
 - [Admin Guide](#admin-guide)
+  - [Prerequisites](#prerequisites)
   - [Setting up](#setting-up)
   - [Notification management](#notification-management)
   - [System Admin slash commands](#system-admin-slash-commands)
@@ -16,10 +17,15 @@ This repository is licensed under the [Apache 2.0 License](https://github.com/ma
   - [Slash commands](#slash-commands)
   - [Create a ticket](#create-a-ticket)
 - [Development](#development)
+- [Provision](#provision)
 
 ## Admin Guide
 
 This guide is intended for Mattermost System Admins setting up the Zendesk app. For more information about contributing to this plugin, visit the [Development section](#development).
+
+### Prerequisites
+
+The Zendesk App is designed using the [Apps Framework](https://developers.mattermost.com/integrate/apps) which differs from the Plugin Framework. The Apps framework is written as a [Mattermost plugin](https://github.com/mattermost/mattermost-plugin-apps) and needs to be installed and enabled before Mattermost Apps like the Zendesk App can be installed. You can install the Apps plugin via the Mattermost Marketplace.
 
 ### Setting up
 
@@ -130,7 +136,7 @@ Start the node server
 
 ## Provision
 
-To provision this app to AWS run `make dist` to generate the App bundle and then follow the steps [here](https://github.com/mattermost/mattermost-plugin-apps#provisioning).
+To provision this app to AWS run `make dist` to generate the App bundle and then follow the steps in the [Deployment (AWS)](https://developers.mattermost.com/integrate/apps/deployment-aws) section of the App Developers Preview online documentation.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This guide is intended for Mattermost System Admins setting up the Zendesk app. 
 
 ### Prerequisites
 
-The Zendesk App is designed using the [Apps Framework](https://developers.mattermost.com/integrate/apps) which differs from the Plugin Framework. The Apps framework is written as a [Mattermost plugin](https://github.com/mattermost/mattermost-plugin-apps) and needs to be installed and enabled before Mattermost Apps like the Zendesk App can be installed. You can install the Apps plugin via the Mattermost Marketplace.
+The Zendesk App is designed using the [Apps Framework](https://developers.mattermost.com/integrate/apps) which differs from the Plugin Framework. You must install and enable the [Mattermost Apps Plugin](https://github.com/mattermost/mattermost-plugin-apps) before Mattermost Apps like the Zendesk App can be installed. You can install the Apps plugin via the Mattermost Marketplace.
 
 ### Setting up
 


### PR DESCRIPTION
#### Summary

This PR adds the following:
* prerequisites section which explains the need for the Apps plugin
* updates AWS deployment link to docs.mattermost.com instead of apps github repo. 

This is needed after some questions posed in this issue comment from a customer. https://github.com/mattermost/mattermost-app-zendesk/issues/72#issuecomment-885683526

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37568