### PR TITLE
[MM-37995] Use modal label fields

### DIFF
--- a/src/forms/create_ticket.ts
+++ b/src/forms/create_ticket.ts
@@ -241,7 +241,7 @@ class FormFields extends BaseFormFields {
             name: CreateTicketFields.NameAdditionalMessage,
             type: AppFieldTypes.TEXT,
             subtype: 'textarea',
-            label: 'Optional message',
+            modal_label: 'Optional message',
             options: makeFormOptions(this.zdTicketForms),
             description: 'Add additional message to the Zendesk ticket',
         };
@@ -253,7 +253,7 @@ class FormFields extends BaseFormFields {
             name: CreateTicketFields.NamePostMessage,
             type: AppFieldTypes.TEXT,
             subtype: 'textarea',
-            label: 'Mattermost message',
+            modal_label: 'Mattermost message',
             value: this.postMessage,
             is_required: true,
             readonly: true,

--- a/src/forms/subscriptions.ts
+++ b/src/forms/subscriptions.ts
@@ -354,7 +354,7 @@ class FormFields extends BaseFormFields {
 
         const f: AppField = {
             name: SubscriptionFields.SubSelectName,
-            label: SubscriptionFields.SubSelectLabel,
+            modal_label: SubscriptionFields.SubSelectLabel,
             type: AppFieldTypes.STATIC_SELECT,
             options,
             is_required: true,

--- a/src/forms/zendesk_config.ts
+++ b/src/forms/zendesk_config.ts
@@ -88,7 +88,7 @@ class FormFields extends BaseFormFields {
         const f: AppField = {
             type: AppFieldTypes.TEXT,
             name: 'zd_client_id',
-            label: 'Client ID',
+            modal_label: 'Client ID',
             value: this.OauthValues.client_id,
             description: 'Client ID obtained from Zendesk Oauth client Unique Identifier',
             is_required: true,
@@ -100,7 +100,7 @@ class FormFields extends BaseFormFields {
             type: AppFieldTypes.TEXT,
             subtype: 'password',
             name: 'zd_client_secret',
-            label: 'Client Secret',
+            modal_label: 'Client Secret',
             value: this.OauthValues.client_secret,
             description: 'Client Secret obtained from Zendesk Oauth client secret',
             is_required: true,

--- a/src/utils/helper_classes/fields/fields_builder.ts
+++ b/src/utils/helper_classes/fields/fields_builder.ts
@@ -53,6 +53,7 @@ class FieldsBuilderImpl implements FieldsBuilder {
         const field: AppField = {
             name: f.name,
             label: f.label,
+            modal_label: f.modal_label,
             type: f.type,
             hint: f.hint,
             subtype: f.subtype,


### PR DESCRIPTION
#### Summary
This PR converts `label` fields to `modal_label` for form fields that only show in the modal.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37995