### PR TITLE
[MM-49438] Only provide http deployment information in local mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: node_modules
 .PHONY: run
 ## run: runs the service
 run:# build
-	LOCAL=true $(NPM) run start
+	$(NPM) run start
 
 .PHONY: test
 ## test: runs all tests

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -34,8 +34,5 @@
                 "runtime": "nodejs14.x"
             }
         ]
-    },
-    "http": {
-        "use_jwt": false
     }
 }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,6 +1,6 @@
 import manifest from './manifest.json';
 
-import {getHTTPPath} from './index';
+import {getHTTPPath, isRunningInHTTPMode} from './index';
 
 export type Manifest = {
     app_id: string;
@@ -11,8 +11,8 @@ export type Manifest = {
     icon: string;
     requested_permissions: string[];
     requested_locations: string[];
-    http: {
-        root_url?: string;
+    http?: {
+        root_url: string;
         use_jwt: boolean;
     }
     aws_lambda: {
@@ -28,7 +28,12 @@ export type Manifest = {
 export function getManifest(): Manifest {
     const m: Manifest = manifest;
 
-    m.http.root_url = getHTTPPath();
+    if (isRunningInHTTPMode()) {
+        m.http = {
+            root_url: getHTTPPath(),
+            use_jwt: true,
+        };
+    }
 
     return m;
 }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -31,7 +31,7 @@ export function getManifest(): Manifest {
     if (isRunningInHTTPMode()) {
         m.http = {
             root_url: getHTTPPath(),
-            use_jwt: true,
+            use_jwt: false,
         };
     }
 


### PR DESCRIPTION
#### Summary
The validation check has become more strict and does not allow "half-backed" HTTP deployment information in the manifest. Hence, it's better to omit that information in lambda mode.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49438
